### PR TITLE
4.6 default node selector and compute nodes

### DIFF
--- a/manifests.yaml
+++ b/manifests.yaml
@@ -46,7 +46,7 @@
       insertafter: '^\s{6}metadata:$'
       line: '        labels:'
 
-  - name: Add label
+  - name: Add label for default node selector
     lineinfile:
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
       insertafter: '^\s{8}labels:$'

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -40,6 +40,24 @@
       insertafter: '^\s{10}image.*$'
       line: '          serverGroupID: {{ workerDefault.id }}'
 
+  - name: Add labels yaml block
+    lineinfile:
+      path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      insertafter: '^\s{6}metadata:$'
+      line: '        labels:'
+
+  - name: Add label
+    lineinfile:
+      path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      insertafter: '^\s{8}labels:$'
+      line: '          node-role.kubernetes.io/app: ""'
+
+  - name: Set worker scale to 2
+    replace:
+      path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      regexp: '^\s{2}replicas: 0$'
+      replace: '  replicas: 2'
+
   - name: Generate ignition configs
     command: openshift-install create ignition-configs --dir=./
 

--- a/security-groups.yaml
+++ b/security-groups.yaml
@@ -357,6 +357,21 @@
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
 
+  - name: 'Create infra-sg rule "Ingress HTTP internal"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_infra }}"
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      protocol: tcp
+      port_range_min: 80
+      port_range_max: 80
+
+  - name: 'Create infra-sg rule "Ingress HTTPS internal"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_infra }}"
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      protocol: tcp
+      port_range_min: 443
+      port_range_max: 443
 
   - name: 'Create api-sg rule "OpenShift API" internal'
     os_security_group_rule:

--- a/security-groups.yaml
+++ b/security-groups.yaml
@@ -357,22 +357,6 @@
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
 
-  - name: 'Create infra-sg rule "Ingress HTTP internal"'
-    os_security_group_rule:
-      security_group: "{{ os_sg_infra }}"
-      remote_ip_prefix: "{{ os_subnet_range }}"
-      protocol: tcp
-      port_range_min: 80
-      port_range_max: 80
-
-  - name: 'Create infra-sg rule "Ingress HTTPS internal"'
-    os_security_group_rule:
-      security_group: "{{ os_sg_infra }}"
-      remote_ip_prefix: "{{ os_subnet_range }}"
-      protocol: tcp
-      port_range_min: 443
-      port_range_max: 443
-
   - name: 'Create api-sg rule "OpenShift API" internal'
     os_security_group_rule:
       security_group: "{{ os_sg_api }}"

--- a/security-groups.yaml
+++ b/security-groups.yaml
@@ -374,7 +374,6 @@
       port_range_max: 6443
     loop: "{{ apiAllowedSources }}"
 
-
   - name: 'Create ingress-sg rule "Ingress HTTP internal"'
     os_security_group_rule:
       security_group: "{{ os_sg_ingress }}"

--- a/security-groups.yaml
+++ b/security-groups.yaml
@@ -189,7 +189,6 @@
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
 
-
   - name: 'Create worker-sg rule "ICMP"'
     os_security_group_rule:
       security_group: "{{ os_sg_worker }}"
@@ -272,7 +271,6 @@
       security_group: "{{ os_sg_worker }}"
       protocol: '112'
       remote_ip_prefix: "{{ os_subnet_range }}"
-
 
   - name: 'Create infra-sg rule "ICMP"'
     os_security_group_rule:


### PR DESCRIPTION
Adds default node selector label to 'default workers' also scales them to 2 out of the box. Can be changed down the line when we decide what machinesets etc. we want.