### PR TITLE
Change to work with v4.7 prerelease

### DIFF
--- a/manifests.yaml
+++ b/manifests.yaml
@@ -40,17 +40,11 @@
       insertafter: '^\s{10}image.*$'
       line: '          serverGroupID: {{ workerDefault.id }}'
 
-  - name: Add labels yaml block
-    lineinfile:
-      path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
-      insertafter: '^\s{6}metadata:$'
-      line: '        labels:'
-
   - name: Add label for default node selector
-    lineinfile:
+    replace:
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
-      insertafter: '^\s{8}labels:$'
-      line: '          node-role.kubernetes.io/app: ""'
+      regexp: '^\s{6}metadata:.*'
+      replace: '      metadata:\n        labels:\n          node-role.kubernetes.io/app: ""'      
 
   - name: Set worker scale to 2
     replace:


### PR DESCRIPTION
Slight change to default nodeselector manifest change to work with v4.7 - also tested with 4.6.9

v4.7 default manifests are a little different, including "metadata: {}" - curly brackets stopped the original regex from finding it.