### PR TITLE
Net2 initial code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
 
 ## Destroying state in directory to prepare for a fresh test install (at your own risk - for testing only!):
 ```
-rm *.ign; rm *.json; rm -rf ./auth; rm inventory.yaml; rm openshift_ke*
+rm *.ign *.json inventory.yaml openshift_ke* .openshift_install_state.json; rm -rf ./auth
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ oc delete MachineSets --all -n openshift-machine-api
 sleep 60
 # Default IC never dies ...
 oc scale IngressControllers default --replicas=0 -n openshift-ingress-operator
-# Wait for workers/infra/net2 to vanish
+# Wait for workers/infra/net2 to vanish - last worker takes ages...
 watch -n5 oc get nodes
 
 ansible-playbook -i ./inventory.yaml ./down-compute-nodes.yaml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To run deployment fill out `vars.yml` and `files/pull-secret.txt`, and then run:
 
 `./deploy.sh`
 
-The rhcos image, floating IP creation, pull-secret and ssh key are not currently part of the code and need to be created/downloaded manually, and then referenced in `vars.yml`
+The rhcos image, floating IP creation and pull-secret are not currently part of the code and need to be created/downloaded manually, and then referenced in `vars.yml`
 
 
 

--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ To generate ignition config and manifests necessary to run the deployment ansibl
 ansible-playbook -e @vars.yml manifests.yaml
 
 The rhcos image, clouds.yaml, pull-secret and ssh key are not currently part of the code and need to be created/downloaded manually.
+
+
+
+
+
+## Rough method for destroying cluster (for quick testing ONLY)
+```
+oc delete IngressControllers --all -n openshift-ingress-operator      
+sleep 10
+oc delete MachineSets --all -n openshift-machine-api
+sleep 20
+# Default IC never dies ...
+oc scale IngressControllers default --replicas=0 -n openshift-ingress-operator
+sleep 120     
+ansible-playbook -i ./inventory.yaml ./down-compute-nodes.yaml
+ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
+ansible-playbook -i ./inventory.yaml ./down-bootstrap.yaml
+ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
+ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
+ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
+ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
+```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ ansible-playbook -i ./inventory.yaml ./down-compute-nodes.yaml
 ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
 ansible-playbook -i ./inventory.yaml ./down-bootstrap.yaml
 ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
+# The down-network playbook needs to be run twice due to ha_router port removal occasionally failing
+ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
 ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml

--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ The rhcos image, clouds.yaml, pull-secret and ssh key are not currently part of 
 oc delete IngressControllers --all -n openshift-ingress-operator      
 sleep 10
 oc delete MachineSets --all -n openshift-machine-api
-sleep 20
+sleep 60
 # Default IC never dies ...
 oc scale IngressControllers default --replicas=0 -n openshift-ingress-operator
-sleep 120     
+# Wait for workers/infra/net2 to vanish
+watch -n5 oc get nodes
+
 ansible-playbook -i ./inventory.yaml ./down-compute-nodes.yaml
 ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
 ansible-playbook -i ./inventory.yaml ./down-bootstrap.yaml

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
 ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
 ```
 
-## Destroying state in directory to prepare for a fresh test install (for testing only!):
+## Destroying state in directory to prepare for a fresh test install (at your own risk - for testing only!):
 ```
 rm *.ign; rm *.json; rm -rf ./auth; rm inventory.yaml; rm openshift_ke*
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
 ansible-playbook -i ./inventory.yaml ./down-bootstrap.yaml
 ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
+ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
 ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The rhcos image, clouds.yaml, pull-secret and ssh key are not currently part of 
 
 
 
-## Rough method for destroying cluster (for quick testing ONLY)
+## Rough method for destroying cluster (for testing ONLY)
 ```
 oc delete IngressControllers --all -n openshift-ingress-operator      
 sleep 10
@@ -27,4 +27,9 @@ ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
 ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
+```
+
+## Destroying state in directory to prepare for a fresh test install (for testing only!):
+```
+rm *.ign; rm *.json; rm -rf ./auth; rm inventory.yaml; rm openshift_ke*
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
 ansible-playbook -i ./inventory.yaml ./down-bootstrap.yaml
 ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
-ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-server-groups.yaml
 ansible-playbook -i ./inventory.yaml ./down-security-groups.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # openshift-upi-ansible
 OpenShift Ansible playbooks to provision infrastructure on a cloud platform
 
-To generate ignition config and manifests necessary to run the deployment ansible playbooks fill out vars.yml and then run:
+To run deployment fill out `vars.yml` and `files/pull-secret.txt`, and then run:
 
-ansible-playbook -e @vars.yml manifests.yaml
+`./deploy.sh`
 
-The rhcos image, clouds.yaml, pull-secret and ssh key are not currently part of the code and need to be created/downloaded manually.
-
+The rhcos image, floating IP creation, pull-secret and ssh key are not currently part of the code and need to be created/downloaded manually, and then referenced in `vars.yml`
 
 
 

--- a/bastion.yaml
+++ b/bastion.yaml
@@ -22,6 +22,10 @@
       security_groups:
       - "{{ os_sg_ssh }}"
 
+  - name: 'Set tag on the bastion port'
+    command:
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ infrastructureID.stdout }}-bastion-port"
+
   - name: Create bastion server
     os_server:
       name: "{{ infrastructureID.stdout }}-bastion"

--- a/common.yaml
+++ b/common.yaml
@@ -54,3 +54,4 @@
       # Security groups names
       os_net2_sg_worker: "{{ infraID }}-net2-worker"
       os_net2_sg_ingress: "{{ infraID }}-net2-ingress"
+    when: net2 | default(false) | bool

--- a/common.yaml
+++ b/common.yaml
@@ -42,16 +42,3 @@
       os_svc_subnet: "{{ infraID }}-kuryr-service-subnet"
       # Ignition files
       os_bootstrap_ignition: "{{ infraID }}-bootstrap-ignition.json"
-
-  - name: 'Net2 Compute resource names'
-    set_fact:
-      os_net2_network_tag: "{{ infraID }}-net2Network"
-      os_net2_network: "{{ infraID }}-net2-network"
-      os_net2_subnet: "{{ infraID }}-net2-nodes"
-      os_net2_router: "{{ infraID }}-net2-external-router"
-      # Port names
-      os_net2_port_ingress: "{{ infraID }}-net2-ingress-port"     
-      # Security groups names
-      os_net2_sg_worker: "{{ infraID }}-net2-worker"
-      os_net2_sg_ingress: "{{ infraID }}-net2-ingress"
-    when: net2 | default(false) | bool

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 set -xe
 
 ssh-keygen -t rsa -b 4096 -N '' -f openshift_key

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -9,9 +9,9 @@
   when: net2 | default(false) | bool
 
 - import_playbook: eg-security-groups.yaml
-  when: extraGatewayForPriNet | default(false) | bool
+  when: extraGateway | default(false) | bool
 - import_playbook: eg-network.yaml
-  when: extraGatewayForPriNet | default(false) | bool
+  when: extraGateway | default(false) | bool
 
 - import_playbook: bootstrap.yaml
 - import_playbook: control-plane.yaml

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -9,9 +9,9 @@
   when: net2 | default(false) | bool
 
 - import_playbook: eg-security-groups.yaml
-  when: extraGateway | default(false) | bool
+  when: extraGatewayForPriNet | default(false) | bool
 - import_playbook: eg-network.yaml
-  when: extraGateway | default(false) | bool
+  when: extraGatewayForPriNet | default(false) | bool
 
 - import_playbook: bootstrap.yaml
 - import_playbook: control-plane.yaml

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -7,7 +7,12 @@
   when: net2 | default(false) | bool
 - import_playbook: net2-network.yaml
   when: net2 | default(false) | bool
-  
+
+- import_playbook: eg-security-groups.yaml
+  when: extraGateway | default(false) | bool
+- import_playbook: eg-network.yaml
+  when: extraGateway | default(false) | bool
+
 - import_playbook: bootstrap.yaml
 - import_playbook: control-plane.yaml
 

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -13,6 +13,11 @@
 - import_playbook: eg-network.yaml
   when: extraGateway | default(false) | bool
 
+- import_playbook: eg-net2-routes.yaml 
+  when: 
+    - net2 | default(false) | bool
+    - extraGateway | default(false) | bool
+
 - import_playbook: bootstrap.yaml
 - import_playbook: control-plane.yaml
 

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -23,7 +23,7 @@
 
   - name: 'Remove all routes from EG router on  Pri net'
     command:
-      cmd: "openstack router set --no-route {{ os_net2_router }}"
+      cmd: "openstack router set --no-route {{ os_eg_router }}"
     when: extraGatewayForPriNet | default(false) | bool
 
   - name: 'List ports attached to routers'

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -37,6 +37,12 @@
     with_indexed_items: "{{ router_ports.stdout_lines }}"
     when: net2 | default(false) | bool
 
+  - name: 'Remove the ports from EG router on Pri net'
+    command:
+      cmd: "openstack router remove port {{ os_eg_router }} {{ item.1}}"
+    with_indexed_items: "{{ router_ports.stdout_lines }}"
+    when: extraGatewayForPriNet | default(false) | bool
+
   - name: 'List ha ports attached to router'
     command:
       cmd: "openstack port list --device-owner=network:ha_router_replicated_interface --tags {{ cluster_id_tag }} -f value -c id"
@@ -52,6 +58,12 @@
       cmd: "openstack router remove port {{ os_net2_router }} {{ item.1}}"
     with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
     when: net2 | default(false) | bool
+
+  - name: 'Remove the ha ports from EG router on Pri net'
+    command:
+      cmd: "openstack router remove port {{ os_net2_router }} {{ item.1}}"
+    with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
+    when: extraGatewayForPriNet | default(false) | bool
 
   - name: 'List ports'
     command:

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -8,7 +8,7 @@
 - import_playbook: net2-common.yaml
   when: net2 | default(false) | bool
 - import_playbook: eg-common.yaml
-  when: extraGatewayForPriNet | default(false) | bool
+  when: extraGateway | default(false) | bool
 
 - hosts: all
   gather_facts: no
@@ -26,7 +26,7 @@
   - name: 'Remove all routes from EG router on  Pri net'
     command:
       cmd: "openstack router set --no-route {{ os_eg_router }}"
-    when: extraGatewayForPriNet | default(false) | bool
+    when: extraGateway | default(false) | bool
 
   - name: 'List ports attached to routers'
     command:
@@ -48,7 +48,7 @@
     command:
       cmd: "openstack router remove port {{ os_eg_router }} {{ item.1}}"
     with_indexed_items: "{{ router_ports.stdout_lines }}"
-    when: extraGatewayForPriNet | default(false) | bool
+    when: extraGateway | default(false) | bool
 
   - name: 'List ha ports attached to router'
     command:
@@ -70,7 +70,7 @@
     command:
       cmd: "openstack router remove port {{ os_eg_router }} {{ item.1}}"
     with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
-    when: extraGatewayForPriNet | default(false) | bool
+    when: extraGateway | default(false) | bool
 
   - name: 'List ports'
     command:
@@ -97,7 +97,7 @@
     os_router:
       name: "{{ os_eg_router }}"
       state: absent
-    when: extraGatewayForPriNet | default(false) | bool
+    when: extraGateway | default(false) | bool
 
   - name: 'List cluster networks'
     command:

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -21,7 +21,12 @@
       cmd: "openstack router set --no-route {{ os_net2_router }}"
     when: net2 | default(false) | bool
 
-  - name: 'List ports attatched to routers'
+  - name: 'Remove all routes from EG router on  Pri net'
+    command:
+      cmd: "openstack router set --no-route {{ os_net2_router }}"
+    when: extraGatewayForPriNet | default(false) | bool
+
+  - name: 'List ports attached to routers'
     command:
       cmd: "openstack port list --device-owner=network:router_interface --tags {{ cluster_id_tag }} -f value -c id"
     register: router_ports
@@ -61,7 +66,7 @@
 
   - name: 'Remove the ha ports from EG router on Pri net'
     command:
-      cmd: "openstack router remove port {{ os_net2_router }} {{ item.1}}"
+      cmd: "openstack router remove port {{ os_eg_router }} {{ item.1}}"
     with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
     when: extraGatewayForPriNet | default(false) | bool
 
@@ -85,6 +90,12 @@
       name: "{{ os_net2_router }}"
       state: absent
     when: net2 | default(false) | bool
+
+  - name: 'Remove the EG router for Pri net'
+    os_router:
+      name: "{{ os_eg_router }}"
+      state: absent
+    when: extraGatewayForPriNet | default(false) | bool
 
   - name: 'List cluster networks'
     command:

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -5,12 +5,23 @@
 # openstacksdk
 
 - import_playbook: common.yaml
+- import_playbook: net2-common.yaml
+  when: net2 | default(false) | bool
 
 - hosts: all
   gather_facts: no
 
   tasks:
-  - name: 'List ports attatched to router'
+  - name: 'Remove all routes from router'
+    command:
+      cmd: "openstack router set --no-route {{ os_router }}"
+
+  - name: 'Remove all routes from Net2 router'
+    command:
+      cmd: "openstack router set --no-route {{ os_net2_router }}"
+    when: net2 | default(false) | bool
+
+  - name: 'List ports attatched to routers'
     command:
       cmd: "openstack port list --device-owner=network:router_interface --tags {{ cluster_id_tag }} -f value -c id"
     register: router_ports
@@ -19,6 +30,12 @@
     command:
       cmd: "openstack router remove port {{ os_router }} {{ item.1}}"
     with_indexed_items: "{{ router_ports.stdout_lines }}"
+
+  - name: 'Remove the ports from Net2 router'
+    command:
+      cmd: "openstack router remove port {{ os_net2_router }} {{ item.1}}"
+    with_indexed_items: "{{ router_ports.stdout_lines }}"
+    when: net2 | default(false) | bool
 
   - name: 'List ha ports attached to router'
     command:
@@ -29,6 +46,12 @@
     command:
       cmd: "openstack router remove port {{ os_router }} {{ item.1}}"
     with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
+
+  - name: 'Remove the ha ports from Net2 router'
+    command:
+      cmd: "openstack router remove port {{ os_net2_router }} {{ item.1}}"
+    with_indexed_items: "{{ ha_router_ports.stdout_lines }}"
+    when: net2 | default(false) | bool
 
   - name: 'List ports'
     command:
@@ -44,6 +67,12 @@
     os_router:
       name: "{{ os_router }}"
       state: absent
+
+  - name: 'Remove the Net2 router'
+    os_router:
+      name: "{{ os_net2_router }}"
+      state: absent
+    when: net2 | default(false) | bool
 
   - name: 'List cluster networks'
     command:

--- a/down-network.yaml
+++ b/down-network.yaml
@@ -7,6 +7,8 @@
 - import_playbook: common.yaml
 - import_playbook: net2-common.yaml
   when: net2 | default(false) | bool
+- import_playbook: eg-common.yaml
+  when: extraGatewayForPriNet | default(false) | bool
 
 - hosts: all
   gather_facts: no

--- a/down-server-groups.yaml
+++ b/down-server-groups.yaml
@@ -8,3 +8,9 @@
     - "worker-default"
     - "infra"
     - "controlplane"
+
+  - name: Remove net2 server group
+    openstack.cloud.server_group:
+      state: absent
+      name: "worker-net2"
+    when: net2 | default(false) | bool

--- a/eg-common.yaml
+++ b/eg-common.yaml
@@ -12,4 +12,4 @@
       os_eg_port_ingress: "{{ infraID }}-eg-ingress-port"     
       # Security groups names
       os_eg_sg_ingress: "{{ infraID }}-eg-ingress"
-    when: extraGatewayForPriNet | default(false) | bool
+    when: extraGateway | default(false) | bool

--- a/eg-common.yaml
+++ b/eg-common.yaml
@@ -1,0 +1,15 @@
+- hosts: localhost
+  gather_facts: no
+
+  vars_files:
+  - metadata.json
+
+  tasks:
+  - name: 'Extra gateway resource names'
+    set_fact:
+      os_eg_router: "{{ infraID }}-eg-external-router"
+      # Port names
+      os_eg_port_ingress: "{{ infraID }}-eg-ingress-port"     
+      # Security groups names
+      os_eg_sg_ingress: "{{ infraID }}-eg-ingress"
+    when: extraGateway | default(false) | bool

--- a/eg-common.yaml
+++ b/eg-common.yaml
@@ -12,4 +12,4 @@
       os_eg_port_ingress: "{{ infraID }}-eg-ingress-port"     
       # Security groups names
       os_eg_sg_ingress: "{{ infraID }}-eg-ingress"
-    when: extraGateway | default(false) | bool
+    when: extraGatewayForPriNet | default(false) | bool

--- a/eg-net2-routes.yaml
+++ b/eg-net2-routes.yaml
@@ -1,0 +1,25 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+# netaddr
+
+- import_playbook: common.yaml
+- import_playbook: eg-common.yaml
+- import_playbook: net2-common.yaml  
+
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  - name: 'Set Extra Gateway routes on Net2 subnet, pointing towards Pri network router'
+    command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
+    loop: "{{ egRoutesOnNet2Network }}" 
+
+  - name: 'Set routes on Primary router to send traffic onwards to EG router'
+    command: openstack router set --route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"  "{{ os_router }}"
+    loop: "{{ egRoutesOnNet2Network }}"
+
+  - name: 'Set a return route for the Net2 subnet on the EG router'
+    command: openstack router set --route "destination={{ os_net2_subnet_range }},gateway={{ os_subnet_range | next_nth_usable(1) }}"  "{{ os_eg_router }}"

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -42,5 +42,5 @@
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
     
   - name: 'Set Extra Gateway routes on Primary subnet'
-    command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') }}"  "{{ os_subnet }}"
+    command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"  "{{ os_subnet }}"
     loop: "{{ egRoutesonPriNetwork }}" 

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -8,7 +8,7 @@
 - import_playbook: common.yaml
 - import_playbook: eg-common.yaml
 
-  - name: 'Create Extra Gateway external router'
+  - name: 'Create Extra Gateway external router on Primary subnet'
     os_router:
       name: "{{ os_eg_router }}"
       network: "{{ os_eg_external_network }}"
@@ -18,7 +18,7 @@
         portip: "{{ os_subnet_range | ipaddr('last_usable') }}"
     when: os_eg_external_network is defined and os_eg_external_network|length>0
 
-  - name: 'Create the EG Ingress port'
+  - name: 'Create the EG Ingress port on Primary subnet'
     os_port:
       name: "{{ os_eg_port_ingress }}"
       network: "{{ os_network }}"
@@ -41,6 +41,6 @@
       cmd: "openstack floating ip set --port {{ os_eg_port_ingress }} {{ os_eg_ingress_fip }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
     
-  - name: 'Set Extra Gateway routes on subnet'
+  - name: 'Set Extra Gateway routes on Primary subnet'
     command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') }}"  "{{ os_subnet }}"
-    loop: "{{ egRoutes }}" 
+    loop: "{{ egRoutesonPriNetwork }}" 

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -8,6 +8,10 @@
 - import_playbook: common.yaml
 - import_playbook: eg-common.yaml
 
+- hosts: all
+  gather_facts: no
+
+  tasks:
   - name: 'Create Extra Gateway external router on Primary subnet'
     os_router:
       name: "{{ os_eg_router }}"

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -47,4 +47,4 @@
     
   - name: 'Set Extra Gateway routes on Primary subnet'
     command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"  "{{ os_subnet }}"
-    loop: "{{ egRoutesonPriNetwork }}" 
+    loop: "{{ egRoutesOnPriNetwork }}" 

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -1,0 +1,46 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+# netaddr
+
+- import_playbook: common.yaml
+- import_playbook: eg-common.yaml
+
+  - name: 'Create Extra Gateway external router'
+    os_router:
+      name: "{{ os_eg_router }}"
+      network: "{{ os_eg_external_network }}"
+      interfaces:
+      - net: "{{ os_network }}"
+        subnet: "{{ os_subnet }}"
+        portip: "{{ os_subnet_range | ipaddr('last_usable') }}"
+    when: os_eg_external_network is defined and os_eg_external_network|length>0
+
+  - name: 'Create the EG Ingress port'
+    os_port:
+      name: "{{ os_eg_port_ingress }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_eg_sg_ingress }}"
+      fixed_ips:
+      - subnet: "{{ os_subnet }}"
+        ip_address: "{{ os_eg_ingressVIP }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
+
+  - name: 'Set the EG Ingress port tag'
+    command:
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_eg_port_ingress }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
+
+  # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
+  # ports, let's use the CLI instead
+  - name: 'Attach the EG Ingress floating IP to Ingress port'
+    command:
+      cmd: "openstack floating ip set --port {{ os_eg_port_ingress }} {{ os_eg_ingress_fip }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
+    
+  - name: 'Set Extra Gateway routes on subnet'
+    command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_subnet_range | ipaddr('last_usable') }}"  "{{ os_subnet }}"
+    loop: "{{ egRoutes }}" 

--- a/eg-network.yaml
+++ b/eg-network.yaml
@@ -15,7 +15,7 @@
       interfaces:
       - net: "{{ os_network }}"
         subnet: "{{ os_subnet }}"
-        portip: "{{ os_subnet_range | ipaddr('last_usable') }}"
+        portip: "{{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"
     when: os_eg_external_network is defined and os_eg_external_network|length>0
 
   - name: 'Create the EG Ingress port on Primary subnet'

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -28,7 +28,7 @@
       protocol: tcp
       port_range_min: 80
       port_range_max: 80
-    loop: "{{ egIngressAllowedSources }}"
+    loop: "{{ egIngressAllowedSourcesForPriNet }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
 
   - name: 'Create eg-ingress-sg rule "Extra Gateway Igress HTTPS external"'
@@ -38,5 +38,5 @@
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
-    loop: "{{ egIngressAllowedSources }}"
+    loop: "{{ egIngressAllowedSourcesForPriNet }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -31,7 +31,7 @@
     loop: "{{ egIngressAllowedSources }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
 
-  - name: 'Create eg-ingress-sg rule "Extra Gateway Igress HTTPS external"'
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS external"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
       remote_ip_prefix: "{{ item }}"

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -28,7 +28,7 @@
       protocol: tcp
       port_range_min: 80
       port_range_max: 80
-    loop: "{{ egIngressAllowedSourcesForPriNet }}"
+    loop: "{{ egIngressAllowedSources }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
 
   - name: 'Create eg-ingress-sg rule "Extra Gateway Igress HTTPS external"'
@@ -38,5 +38,5 @@
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
-    loop: "{{ egIngressAllowedSourcesForPriNet }}"
+    loop: "{{ egIngressAllowedSources }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -1,0 +1,42 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+
+- import_playbook: common.yaml
+- import_playbook: eg-common.yaml
+
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  - name: 'Create the Extra Gateway ingress security group'
+    os_security_group:
+      name: "{{ os_eg_sg_ingress }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
+
+  - name: 'Set EG ingress security group tag'
+    command:
+      cmd: "openstack security group set --tag {{ cluster_id_tag }} {{ os_eg_sg_ingress }} "
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
+
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP external"'
+    os_security_group_rule:
+      security_group: "{{ os_eg_sg_ingress }}"
+      remote_ip_prefix: "{{ item }}"
+      protocol: tcp
+      port_range_min: 80
+      port_range_max: 80
+    loop: "{{ egIngressAllowedSources }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
+
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Igress HTTPS external"'
+    os_security_group_rule:
+      security_group: "{{ os_eg_sg_ingress }}"
+      remote_ip_prefix: "{{ item }}"
+      protocol: tcp
+      port_range_min: 443
+      port_range_max: 443
+    loop: "{{ egIngressAllowedSources }}"
+    when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -53,11 +53,11 @@
       regexp: '^\s{6}metadata:.*'
       replace: '      metadata:\n        labels:\n          node-role.kubernetes.io/app: ""'      
 
-  - name: Set worker scale to 2
+  - name: Set worker scale
     replace:
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
       regexp: '^\s{2}replicas: 0$'
-      replace: '  replicas: 2'
+      replace: '  replicas: {{ initialWorkerCount }}'
 
   - name: Generate ignition configs
     command: openshift-install create ignition-configs --dir=./

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -34,6 +34,13 @@
       regexp: '^\s{2}mastersSchedulable: true$'
       replace: '  mastersSchedulable: False'
 
+
+- import_playbook: net2-manifests.yaml
+  when: net2 | default(false) | bool
+
+
+- hosts: localhost
+  tasks:
   - name: Set worker server groups
     lineinfile:
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml

--- a/net2-common.yaml
+++ b/net2-common.yaml
@@ -1,0 +1,19 @@
+- hosts: localhost
+  gather_facts: no
+
+  vars_files:
+  - metadata.json
+
+  tasks:
+  - name: 'Net2 Compute resource names'
+    set_fact:
+      os_net2_network_tag: "{{ infraID }}-net2Network"
+      os_net2_network: "{{ infraID }}-net2-network"
+      os_net2_subnet: "{{ infraID }}-net2-nodes"
+      os_net2_router: "{{ infraID }}-net2-external-router"
+      # Port names
+      os_net2_port_ingress: "{{ infraID }}-net2-ingress-port"     
+      # Security groups names
+      os_net2_sg_worker: "{{ infraID }}-net2-worker"
+      os_net2_sg_ingress: "{{ infraID }}-net2-ingress"
+    when: net2 | default(false) | bool

--- a/net2-common.yaml
+++ b/net2-common.yaml
@@ -12,6 +12,7 @@
       os_net2_subnet: "{{ infraID }}-net2-nodes"
       os_net2_router: "{{ infraID }}-net2-external-router"
       # Port names
+      os_net2_port_pri_router: "{{ infraID }}-net2-prirouter-port"
       os_net2_port_ingress: "{{ infraID }}-net2-ingress-port"     
       # Security groups names
       os_net2_sg_worker: "{{ infraID }}-net2-worker"

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -1,0 +1,41 @@
+- import_playbook: common.yaml
+- import_playbook: net2_common.yaml
+
+- hosts: localhost
+  tasks:
+  - name: Copy worker machineset file for net2
+    copy:
+      src: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      dest: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+
+  - name: Set net2 worker server groups
+    lineinfile:
+      path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+      insertafter: '^\s{10}image.*$'
+      line: '          serverGroupID: {{ workerNet2Group.id }}'
+
+  - name: Add label for net2 node selector
+    replace:
+      path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+      regexp: '^\s{6}metadata:.*'
+      replace: '      metadata:\n        labels:\n          node-role.kubernetes.io/net2: ""'
+
+  - name: Set net2 worker scale to 2
+    replace:
+      path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+      regexp: '^\s{2}replicas: 0$'
+      replace: '  replicas: 2'
+
+  - name: Find/replace MachineSet, server and security group name
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml    
+        regexp: "{{ infraID }}-worker"
+        replace: "{{ infraID }}-net2-worker"
+
+  - name: Find/replace subnet name
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+        regexp: "{{ os_subnet }}"
+        replace: "{{ os_net2_subnet }}"
+
+

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -26,13 +26,13 @@
   - name: Find/replace MachineSet, server and security group name
     replace:
         path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml    
-        regexp: "{{ infraID }}-worker"
-        replace: "{{ infraID }}-net2-worker"
+        regexp: "-worker"
+        replace: "-net2-worker"
 
   - name: Find/replace subnet name
     replace:
         path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
-        regexp: "{{ infraID }}-nodes"
-        replace: "{{ infraID }}-net2-nodes"
+        regexp: "-nodes"
+        replace: "-net2-nodes"
 
 

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -17,11 +17,11 @@
       regexp: '^\s{6}metadata:.*'
       replace: '      metadata:\n        labels:\n          node-role.kubernetes.io/net2: ""'
 
-  - name: Set net2 worker scale to 2
+  - name: Set net2 worker scale
     replace:
       path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
       regexp: '^\s{2}replicas: 0$'
-      replace: '  replicas: 2'
+      replace: '  replicas: {{ net2InitialWorkerCount }}'
 
   - name: Find/replace MachineSet, server and security group name
     replace:

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -1,6 +1,3 @@
-- import_playbook: common.yaml
-- import_playbook: net2_common.yaml
-
 - hosts: localhost
   tasks:
   - name: Copy worker machineset file for net2
@@ -35,7 +32,7 @@
   - name: Find/replace subnet name
     replace:
         path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
-        regexp: "{{ os_subnet }}"
-        replace: "{{ os_net2_subnet }}"
+        regexp: "{{ infraID }}-nodes"
+        replace: "{{ infraID }}-net2-nodes"
 
 

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -38,7 +38,9 @@
       name: "{{ os_net2_router }}"
       network: "{{ os_net2_external_network }}"
       interfaces:
-      - "{{ os_net2_subnet }}"
+      - net: "{{ os_net2_network }}"
+        subnet: "{{ os_net2_subnet }}"
+        portip: "{{ os_net2_subnet_range | next_nth_usable(1) }}"
     when: os_net2_external_network is defined and os_net2_external_network|length>0
 
   - name: 'Update primary external router to add interface on the net2 network'
@@ -53,18 +55,18 @@
         portip: "{{ os_net2_cluster_net_router_ip }}"
     when: os_external_network is defined and os_external_network|length>0    
 
-  - name: 'Add route on Net2 router to allow access to primary network'
+  - name: 'Add route on Net2 router to allow access to primary network (for DNS replies to return if necessary)'
     command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_cluster_net_router_ip }}"  "{{ os_net2_router }}"
-
+    when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
     # If we access DNS via the Primary network:
-  - name: 'Set route on Net2 router to allow access to DNS via primary network'
-    command: openstack router set --route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_cluster_net_router_ip }}" --route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_cluster_net_router_ip }}"  "{{ os_net2_router }}"
+  - name: 'Set host route on Net2 subnet to allow access to DNS via primary network'
+    command: openstack subnet set --host-route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_pri_net_router_ip }}" --host-route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
     when: externalDNSisOnNet2 is defined and not externalDNSisOnNet2
 
-    # If we access DNS via Net2 network (assumes the primary router always has first IP in subnet...):
+    # If we access DNS via Net2 network 
   - name: 'Set route on Primary router to allow access to DNS via Net2'
-    command: openstack router set --route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_subnet_range | next_nth_usable(1) }}" --route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
+    command: openstack router set --route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}" --route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
     when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
 # Kuryr tasks removed
@@ -90,9 +92,15 @@
       cmd: "openstack floating ip set --port {{ os_net2_port_ingress }} {{ os_net2_ingress_fip }}"
     when: os_net2_ingress_fip is defined and os_net2_ingress_fip|length>0
 
-  - name: Set DNS on Net2 subnet
+  - name: 'Set DNS on Net2 subnet'
     command: openstack subnet set --dns-nameserver "{{ ExternalDNS[0] }}" --dns-nameserver "{{ ExternalDNS[1] }}"  "{{ os_net2_subnet }}"
 
-  - name: Set routes on Net2 subnet 
+  - name: 'Set routes on Net2 subnet to allow access to primary network'
+    command: openstack subnet set --host-route "destination={{ os_subnet_range }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
+
+  - name: 'Set additional routes on Net2 subnet'
     command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
     loop: "{{ net2RoutesViaPriNetwork }}"
+
+
+

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -46,7 +46,7 @@
 
   - name: 'Create port for primary router on net2 network'
     os_port:
-      name: "pri_router_port"
+      name: "{{ os_net2_port_pri_router }}"
       state: present
       network: "{{ os_net2_network }}"
       fixed_ips: 
@@ -54,11 +54,11 @@
 
   - name: 'Set tag on the new port'
     command:
-      cmd: "openstack port set --tag {{ cluster_id_tag }} pri_router_port"
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_net2_port_pri_router }}"
 
     # os_router module appears unwilling to update existing router to add interface so cmd...    
   - name: 'Connect port to primary router to give access to/from the net2 network'
-    command: openstack router add port "{{ os_router }}" "pri_router_port"
+    command: openstack router add port "{{ os_router }}" "{{ os_net2_port_pri_router }}"
 
     # If we access DNS via the Primary network:
   - name: 'Set host route on Net2 subnet to allow access to DNS via primary network'

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -107,5 +107,3 @@
     command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
     loop: "{{ net2RoutesViaPriNetwork }}"
 
-
-

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -43,30 +43,34 @@
         portip: "{{ os_net2_subnet_range | next_nth_usable(1) }}"
     when: os_net2_external_network is defined and os_net2_external_network|length>0
 
-  - name: 'Update primary external router to add interface on the net2 network'
-    os_router:
-      name: "{{ os_router }}"
+  - name: 'Create port for primary router on net2 network'
+    os_port:
+      name: "pri_router_port"
       state: present
-      network: "{{ os_external_network }}"
-      interfaces:
-      - "{{ os_subnet }}"
-      - net: "{{ os_net2_network }}"
-        subnet: "{{ os_net2_subnet }}"
-        portip: "{{ os_net2_cluster_net_router_ip }}"
-    when: os_external_network is defined and os_external_network|length>0    
+      network: "{{ os_net2_network }}"
+      fixed_ips: 
+      - ip_address: "{{ os_net2_pri_net_router_ip }}"
+
+  - name: 'Set tag on the new port'
+    command:
+      cmd: "openstack port set --tag {{ cluster_id_tag }} pri_router_port"
+
+    # os_router module appears unwilling to update existing router to add interface so cmd...    
+  - name: 'Connect port to primary router to give access to/from the net2 network'
+    command: openstack router add port "{{ os_router }}" "pri_router_port"
 
     # If we access DNS via the Primary network:
   - name: 'Set host route on Net2 subnet to allow access to DNS via primary network'
-    command: openstack subnet set --host-route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_pri_net_router_ip }}" --host-route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
+    command: openstack subnet set --host-route "destination={{ externalDNS[0] }}/32,gateway={{ os_net2_pri_net_router_ip }}" --host-route "destination={{ externalDNS[1] }}/32,gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
     when: externalDNSisOnNet2 is defined and not externalDNSisOnNet2
 
     # If we access DNS via Net2 network 
   - name: 'Set route on Primary router to allow access to DNS via Net2'
-    command: openstack router set --route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}" --route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
+    command: openstack router set --route "destination={{ externalDNS[0] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}" --route "destination={{ externalDNS[1] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
     when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
   - name: 'Add route on Net2 router to allow access to primary network (for DNS replies to return)'
-    command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_cluster_net_router_ip }}"  "{{ os_net2_router }}"
+    command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_router }}"
     when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
 # Kuryr tasks removed
@@ -93,7 +97,7 @@
     when: os_net2_ingress_fip is defined and os_net2_ingress_fip|length>0
 
   - name: 'Set DNS on Net2 subnet'
-    command: openstack subnet set --dns-nameserver "{{ ExternalDNS[0] }}" --dns-nameserver "{{ ExternalDNS[1] }}"  "{{ os_net2_subnet }}"
+    command: openstack subnet set --dns-nameserver "{{ externalDNS[0] }}" --dns-nameserver "{{ externalDNS[1] }}"  "{{ os_net2_subnet }}"
 
   - name: 'Set routes on Net2 subnet to allow access to primary network'
     command: openstack subnet set --host-route "destination={{ os_subnet_range }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -55,10 +55,6 @@
         portip: "{{ os_net2_cluster_net_router_ip }}"
     when: os_external_network is defined and os_external_network|length>0    
 
-  - name: 'Add route on Net2 router to allow access to primary network (for DNS replies to return if necessary)'
-    command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_cluster_net_router_ip }}"  "{{ os_net2_router }}"
-    when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
-
     # If we access DNS via the Primary network:
   - name: 'Set host route on Net2 subnet to allow access to DNS via primary network'
     command: openstack subnet set --host-route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_pri_net_router_ip }}" --host-route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
@@ -67,6 +63,10 @@
     # If we access DNS via Net2 network 
   - name: 'Set route on Primary router to allow access to DNS via Net2'
     command: openstack router set --route "destination={{ ExternalDNS[0] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}" --route "destination={{ ExternalDNS[1] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
+    when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
+
+  - name: 'Add route on Net2 router to allow access to primary network (for DNS replies to return)'
+    command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_cluster_net_router_ip }}"  "{{ os_net2_router }}"
     when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
 # Kuryr tasks removed

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -81,7 +81,7 @@
       name: "{{ os_net2_port_ingress }}"
       network: "{{ os_net2_network }}"
       security_groups:
-      - "{{ os_sg_ingress }}"
+      - "{{ os_net2_sg_ingress }}"
       fixed_ips:
       - subnet: "{{ os_net2_subnet }}"
         ip_address: "{{ os_net2_ingressVIP }}"

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -26,7 +26,7 @@
       network_name: "{{ os_net2_network }}"
       cidr: "{{ os_net2_subnet_range }}"
       allocation_pool_start: "{{ os_net2_subnet_range | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_net2_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"
+      allocation_pool_end: "{{ os_net2_subnet_range | ipaddr('last_usable') | ipmath(-2) }}"
 
   - name: 'Set tags on Net2 subnet'
     command:

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -6,6 +6,7 @@
 # netaddr
 
 - import_playbook: common.yaml
+- import_playbook: net2-common.yaml
 
 - hosts: all
   gather_facts: no

--- a/net2-network.yaml
+++ b/net2-network.yaml
@@ -70,9 +70,8 @@
     command: openstack router set --route "destination={{ externalDNS[0] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}" --route "destination={{ externalDNS[1] }}/32,gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
     when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
-  - name: 'Add route on Net2 router to allow access to primary network (for DNS replies to return)'
+  - name: 'Add route on Net2 router to allow access to primary network'
     command: openstack router set --route "destination={{ ospSubnet }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_router }}"
-    when: externalDNSisOnNet2 is defined and externalDNSisOnNet2
 
 # Kuryr tasks removed
 
@@ -107,3 +106,6 @@
     command: openstack subnet set --host-route "destination={{ item }},gateway={{ os_net2_pri_net_router_ip }}"  "{{ os_net2_subnet }}"
     loop: "{{ net2RoutesViaPriNetwork }}"
 
+  - name: 'Set routes on Primary router to allow selective outbound access from Pri Net via Net2'
+    command: openstack router set --route "destination={{ item }},gateway={{ os_net2_subnet_range | next_nth_usable(1) }}"  "{{ os_router }}"
+    loop: "{{ priNetRoutesViaNet2Network }}"

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -10,6 +10,7 @@
 # and work out which ports all the workers need to talk to each other on (such as mDNS and VXLAN) and remove unnecessary rules)
 
 - import_playbook: common.yaml
+- import_playbook: net2-common.yaml
 
 - hosts: all
   gather_facts: no

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -394,6 +394,78 @@
       protocol: '112'
       remote_ip_prefix: "{{ os_net2_subnet_range }}"
 
+  - name: 'Create net2-worker-sg rule "mDNS" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: udp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 5353
+      port_range_max: 5353
+
+  - name: 'Create net2-worker-sg rule "router" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 1936
+      port_range_max: 1936
+
+  - name: 'Create net2-worker-sg rule "VXLAN" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: udp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 4789
+      port_range_max: 4789
+
+  - name: 'Create net2-worker-sg rule "Geneve" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: udp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 6081
+      port_range_max: 6081
+
+  - name: 'Create net2-worker-sg rule "worker ingress internal (TCP)" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 9000
+      port_range_max: 9999
+
+  - name: 'Create net2-worker-sg rule "worker ingress internal (UDP)" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: udp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 9000
+      port_range_max: 9999
+
+  - name: 'Create net2-worker-sg rule "worker ingress kubelet insecure" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 10250
+      port_range_max: 10250
+
+  - name: 'Create net2-worker-sg rule "worker ingress services (TCP)" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
+  - name: 'Create net2-worker-sg rule "worker ingress services (UDP)" for primary network'
+    os_security_group_rule:
+      security_group: "{{ os_net2_sg_worker }}"
+      protocol: udp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
   - name: 'Create api-sg rule "OpenShift API" internal for Net2 subnet'
     os_security_group_rule:
       security_group: "{{ os_sg_api }}"

--- a/network.yaml
+++ b/network.yaml
@@ -25,7 +25,7 @@
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"
 
   - name: 'Set tags on  primary cluster subnet'
     command:

--- a/network.yaml
+++ b/network.yaml
@@ -25,7 +25,7 @@
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
-      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') | ipmath(-1) }}"
+      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') | ipmath(-2) }}"
 
   - name: 'Set tags on  primary cluster subnet'
     command:

--- a/server-groups.yaml
+++ b/server-groups.yaml
@@ -23,3 +23,12 @@
       policies:
       - anti-affinity
     register: controlplaneGroup 
+
+  - name: Create net2 worker server group
+    openstack.cloud.server_group:
+      state: present
+      name: worker-net2
+      policies:
+      - soft-anti-affinity
+    register: workerNet2Group
+    when: net2 | default(false) | bool

--- a/templates/draft-keepalived-for-net2.yml.jq
+++ b/templates/draft-keepalived-for-net2.yml.jq
@@ -1,0 +1,54 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: net2
+  name: 04-net2keepalived
+  selfLink: /apis/machineconfiguration.openshift.io/v1/machineconfigs/04-net2keepalived
+spec:
+  config:
+    ignition:
+      config: {}
+      timeouts: {}
+      version: 3.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:,%23%20UKCloud%20custom%20config%0Avrrp_script%20chk_ingress%20%7B%0A%20%20%20%20script%20%22%2Fusr%2Fbin%2Ftimeout%200.9%20%2Fusr%2Fbin%2Fcurl%20-o%20%2Fdev%2Fnull%20-Lfs%20http%3A%2F%2Flocalhost%3A1936%2Fhealthz%2Fready%22%0A%20%20%20%20interval%201%0A%20%20%20%20weight%2050%0A%7D%0Avrrp_instance%20%7B%7B%20.Cluster.Name%20%7D%7D_NET2INGRESS%20%7B%0A%20%20%20%20state%20BACKUP%0A%20%20%20%20interface%20ens3%0A%20%20%20%20virtual_router_id%20199%0A%20%20%20%20priority%2040%0A%20%20%20%20advert_int%201%0A%20%20%20%20authentication%20%7B%0A%20%20%20%20%20%20%20%20auth_type%20PASS%0A%20%20%20%20%20%20%20%20auth_pass%20%7B%7B%20.Cluster.Name%20%7D%7D_net2ingress_vip%0A%20%20%20%20%7D%0A%20%20%20%20virtual_ipaddress%20%7B%0A%20%20%20%20%20%20%20%20{{ os_net2_ingressVIP }}%2F24%0A%20%20%20%20%7D%0A%20%20%20%20track_script%20%7B%0A%20%20%20%20%20%20%20%20chk_ingress%0A%20%20%20%20%7D%0A%7D
+        mode: 420
+        overwrite: true
+        path: /etc/kubernetes/static-pod-resources/keepalived/keepalived.conf.tmpl
+    systemd: {}
+  fips: false
+  osImageURL: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: net2
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - { key: machineconfiguration.openshift.io/role, operator: In, values: [ worker, net2 ] }
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/net2: ""
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: net2
+  namespace: openshift-ingress-operator
+spec:
+  domain: net2.7969-278091.cor00005-2.cna.ukcloud.com
+  namespaceSelector:
+    matchLabels:
+      network: net2
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/net2: ""
+  replicas: {{ net2InitialWorkerCount }}

--- a/templates/draft-keepalived-for-net2.yml.jq
+++ b/templates/draft-keepalived-for-net2.yml.jq
@@ -43,7 +43,7 @@ metadata:
   name: net2
   namespace: openshift-ingress-operator
 spec:
-  domain: net2.7969-278091.cor00005-2.cna.ukcloud.com
+  domain: net2.{{ custID }}.{{ baseDomain }}
   namespaceSelector:
     matchLabels:
       network: net2

--- a/templates/draft-keepalived-for-net2.yml.jq
+++ b/templates/draft-keepalived-for-net2.yml.jq
@@ -1,7 +1,7 @@
 # Suggested template which splits the openshift-openstack-infra keepalived using MC and makes an IngressController
 # Needs: 
 # - the actual keepalived.conf.tmpl contents to be sanity checked
-# - the default IngressController needs a negative namespaceSelector added to it so that doesn't pick up net2 routers
+# - the default IngressController needs a negative namespaceSelector added to it so that doesn't pick up net2 routes
 #   or a positive namespaceSelector that makes it only pick up routes for namespaces with label "network: internet", maybe adding
 #   another label in both IG's namespaceSelector's "network: both" ????
 # EG Ingress could be made simlarly but we would need to work out what nodes to site it on...

--- a/templates/draft-keepalived-for-net2.yml.jq
+++ b/templates/draft-keepalived-for-net2.yml.jq
@@ -1,3 +1,10 @@
+# Suggested template which splits the openshift-openstack-infra keepalived using MC and makes an IngressController
+# Needs: 
+# - the actual keepalived.conf.tmpl contents to be sanity checked
+# - the default IngressController needs a negative namespaceSelector added to it so that doesn't pick up net2 routers
+#   or a positive namespaceSelector that makes it only pick up routes for namespaces with label "network: internet", maybe adding
+#   another label in both IG's namespaceSelector's "network: both" ????
+# EG Ingress could be made simlarly but we would need to work out what nodes to site it on...
 ---
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
@@ -17,6 +24,7 @@ spec:
     storage:
       files:
       - contents:
+          # VVV os_net2_ingressVIP is a parameter in this line VVV
           source: data:,%23%20UKCloud%20custom%20config%0Avrrp_script%20chk_ingress%20%7B%0A%20%20%20%20script%20%22%2Fusr%2Fbin%2Ftimeout%200.9%20%2Fusr%2Fbin%2Fcurl%20-o%20%2Fdev%2Fnull%20-Lfs%20http%3A%2F%2Flocalhost%3A1936%2Fhealthz%2Fready%22%0A%20%20%20%20interval%201%0A%20%20%20%20weight%2050%0A%7D%0Avrrp_instance%20%7B%7B%20.Cluster.Name%20%7D%7D_NET2INGRESS%20%7B%0A%20%20%20%20state%20BACKUP%0A%20%20%20%20interface%20ens3%0A%20%20%20%20virtual_router_id%20199%0A%20%20%20%20priority%2040%0A%20%20%20%20advert_int%201%0A%20%20%20%20authentication%20%7B%0A%20%20%20%20%20%20%20%20auth_type%20PASS%0A%20%20%20%20%20%20%20%20auth_pass%20%7B%7B%20.Cluster.Name%20%7D%7D_net2ingress_vip%0A%20%20%20%20%7D%0A%20%20%20%20virtual_ipaddress%20%7B%0A%20%20%20%20%20%20%20%20{{ os_net2_ingressVIP }}%2F24%0A%20%20%20%20%7D%0A%20%20%20%20track_script%20%7B%0A%20%20%20%20%20%20%20%20chk_ingress%0A%20%20%20%20%7D%0A%7D
         mode: 420
         overwrite: true

--- a/templates/install-config.j2
+++ b/templates/install-config.j2
@@ -17,13 +17,13 @@ metadata:
   name: {{ custID }}
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14
+  - cidr: {{ osClusterNetwork | default("10.128.0.0/14") }}
     hostPrefix: 23
   machineNetwork:
   - cidr: {{ ospSubnet }}
   networkType: OpenShiftSDN
   serviceNetwork:
-  - 172.30.0.0/16
+  - {{ osServiceNetwork | default("172.30.0.0/16") }}
 platform:
   openstack:
     apiVIP: {{ os_apiVIP }}

--- a/templates/install-config.j2
+++ b/templates/install-config.j2
@@ -26,7 +26,7 @@ networking:
   - 172.30.0.0/16
 platform:
   openstack:
-    apiVIP: 10.0.0.5
+    apiVIP: {{ os_apiVIP }}
     cloud: openstack
     computeFlavor: ocp.m1.medium
     clusterOSImage: {{ rhcosImage }}
@@ -35,7 +35,7 @@ platform:
     - {{ dnsServer }}
 {% endfor %}
     externalNetwork: internet
-    ingressVIP: 10.0.0.7
+    ingressVIP: {{ os_ingressVIP }}
     lbFloatingIP: {{ apiFIP }}
 publish: External
 pullSecret: '{{ pullSecret }}'

--- a/templates/install-config.j2
+++ b/templates/install-config.j2
@@ -40,3 +40,6 @@ platform:
 publish: External
 pullSecret: '{{ pullSecret }}'
 sshKey: {{ sshKey }}
+{% if disconnectedInstall %}
+{{ installConfigExtraParams }}
+{% endif %}

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -15,6 +15,7 @@ all:
       os_net2_external_network: "{{ net2ExternalNetwork }}"
       os_net2_ingress_fip: "{{ net2IngressFIP }}"
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
+
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
 {% endif %}
 {% if extraGatewayForPriNet %}

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -15,7 +15,8 @@ all:
       os_net2_external_network: "{{ net2ExternalNetwork }}"
       os_net2_ingress_fip: "{{ net2IngressFIP }}"
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
-      os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | last_usable }}"{% endraw %}
+
+      os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
 
       # Service subnet cidr
       svc_subnet_range: '172.30.0.0/16'

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -17,10 +17,10 @@ all:
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
 {% endif %}
-{% if extraGateway %}
-      # Extra Gateway values
-      os_eg_external_network: "{{ egExternalNetwork }}"
-      os_eg_ingress_fip: "{{ egIngressFIP }}"
+{% if extraGatewayForPriNet %}
+      # Extra Gateway values for Primary network
+      os_eg_external_network: "{{ egExternalNetworkForPriNet }}"
+      os_eg_ingress_fip: "{{ egIngressFIPForPriNet }}"
       os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
 {% endif %}
 

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -15,9 +15,15 @@ all:
       os_net2_external_network: "{{ net2ExternalNetwork }}"
       os_net2_ingress_fip: "{{ net2IngressFIP }}"
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
-
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
 {% endif %}
+{% if extraGateway %}
+      # Extra Gateway values
+      os_eg_external_network: "{{ egExternalNetwork }}"
+      os_eg_ingress_fip: "{{ egIngressFIP }}"
+      os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
+{% endif %}
+
       # Service subnet cidr
       svc_subnet_range: '172.30.0.0/16'
       os_svc_network_range: '172.30.0.0/15'

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -10,7 +10,7 @@ all:
       os_flavor_worker: 'ocp.m1.medium'
       os_image_rhcos: "{{ rhcosImage }}"
 {% if net2 %}
-      # Net2 values - gonna need a conditional to allow non-Net2...
+      # Net2 values
       os_net2_subnet_range: "{{ net2OspSubnet }}"
       os_net2_external_network: "{{ net2ExternalNetwork }}"
       os_net2_ingress_fip: "{{ net2IngressFIP }}"

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -17,12 +17,14 @@ all:
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
 
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
+
 {% endif %}
 {% if extraGatewayForPriNet %}
       # Extra Gateway values for Primary network
       os_eg_external_network: "{{ egExternalNetworkForPriNet }}"
       os_eg_ingress_fip: "{{ egIngressFIPForPriNet }}"
       os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
+
 {% endif %}
 
       # Service subnet cidr

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -19,10 +19,10 @@ all:
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
 
 {% endif %}
-{% if extraGatewayForPriNet %}
+{% if extraGateway %}
       # Extra Gateway values for Primary network
-      os_eg_external_network: "{{ egExternalNetworkForPriNet }}"
-      os_eg_ingress_fip: "{{ egIngressFIPForPriNet }}"
+      os_eg_external_network: "{{ egExternalNetwork }}"
+      os_eg_ingress_fip: "{{ egIngressFIP }}"
       os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
 
 {% endif %}

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -24,6 +24,7 @@ all:
       os_eg_external_network: "{{ egExternalNetworkForPriNet }}"
       os_eg_ingress_fip: "{{ egIngressFIPForPriNet }}"
       os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
+
 {% endif %}
 
       # Service subnet cidr

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -24,7 +24,6 @@ all:
       os_eg_external_network: "{{ egExternalNetworkForPriNet }}"
       os_eg_ingress_fip: "{{ egIngressFIPForPriNet }}"
       os_eg_ingressVIP: {% raw %}"{{ os_subnet_range | next_nth_usable(9) }}"{% endraw %}
-
 {% endif %}
 
       # Service subnet cidr

--- a/templates/inventory.j2
+++ b/templates/inventory.j2
@@ -9,7 +9,7 @@ all:
       os_flavor_controlplane: 'ocp.m1.medium'
       os_flavor_worker: 'ocp.m1.medium'
       os_image_rhcos: "{{ rhcosImage }}"
-
+{% if net2 %}
       # Net2 values - gonna need a conditional to allow non-Net2...
       os_net2_subnet_range: "{{ net2OspSubnet }}"
       os_net2_external_network: "{{ net2ExternalNetwork }}"
@@ -17,7 +17,7 @@ all:
       os_net2_ingressVIP: {% raw %}"{{ os_net2_subnet_range | next_nth_usable(7) }}"{% endraw %}
 
       os_net2_pri_net_router_ip: {% raw %}"{{ os_net2_subnet_range | ipaddr('last_usable') }}"{% endraw %}
-
+{% endif %}
       # Service subnet cidr
       svc_subnet_range: '172.30.0.0/16'
       os_svc_network_range: '172.30.0.0/15'

--- a/vars.yml
+++ b/vars.yml
@@ -2,6 +2,7 @@ custID: <Estate API ID for cluster (string)>
 baseDomain: <Base domain for OSP region (string)>
 rhcosImage: <rhcos image present in OSP project (NAME)>
 externalDNS: <List of exactly 2 DNS servers (List of IPaddr)> 
+initialWorkerCount: 2
 
 # Primary network params
 ospSubnet: <Subnet for machines (CIDR)>
@@ -30,6 +31,7 @@ neustarUltraDnsPassword: "password"
 #    or via the primary network (when set to False) - this applies to nodes on both networks!
 net2: False
 externalDNSisOnNet2: False 
+net2InitialWorkerCount: 2
 net2OspSubnet: <Subnet for net2 machines (CIDR)>
 net2ExternalNetwork: <External Network net2 (NAME)>
 net2IngressFIP: <FIP for net2 ingress (IPaddr)>

--- a/vars.yml
+++ b/vars.yml
@@ -1,36 +1,36 @@
-ospSubnet: <Subnet for machines>
-externalNetwork: <Network cluster is on>
-apiFIP: <FIP for controlplane>
-ingressFIP: <FIP for dataplane>
-bootstrapFIP: <FIP for bootstrap access>
+ospSubnet: <Subnet for machines (CIDR)>
+externalNetwork: <Network cluster is on (NAME)>
+apiFIP: <FIP for controlplane (IPaddr)>
+ingressFIP: <FIP for dataplane (IPaddr)>
+bootstrapFIP: <FIP for bootstrap access (IPaddr)>
 custID: <Estate API ID for cluster>
 baseDomain: <Base domain for OSP region>
-rhcosImage: <rhcos image present in OSP project>
-externalDNS: <List of 2 DNS servers> 
+rhcosImage: <rhcos image present in OSP project (NAME)>
+externalDNS: <List of 2 DNS servers (List of IPaddr)> 
 apiAllowedSources: ["0.0.0.0/0"]
 ingressAllowedSources: ["0.0.0.0/0"]
-sshAllowedSources: <Add office IP, VPN IPs and internal network range in list format>
+sshAllowedSources: <Add office IP, VPN IPs and internal network range in list format (List of CIDR)>
 neustarUltraDnsUsername: "username"
 neustarUltraDnsPassword: "password"
 
-# Net2 implements a second subnet for Net2 workers
-#  - it requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install
+# Net2 implements a second subnet for Net2 workers.
+#  - it requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install.
 #  - Net2 playbooks do not support Kuryr...
 #  - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in
-#    openshift-dns is installed on all nodes and the svc round-robins between them
+#    openshift-dns is installed on all nodes and the svc round-robins between them.
 #  - The cluster needs to be able to resolve its own external name (for oauth etc) and its OpenStack cloud API
-#    via the specified externalDNS
-#  - externalDNSisOnNet2 defines whether the externalDNS servers are accessed via Net2 (when set to True)
+#    via the specified externalDNS.
+#  - "externalDNSisOnNet2" defines whether the externalDNS servers are accessed via Net2 (when set to True)
 #    or via the primary network (when set to False) - this applies to nodes on both networks!
 net2: False
 externalDNSisOnNet2: False 
-net2OspSubnet: <Subnet for net2 machines>
-net2ExternalNetwork: <External Network net2>
-net2IngressFIP: <FIP for net2 ingress>
+net2OspSubnet: <Subnet for net2 machines (CIDR)>
+net2ExternalNetwork: <External Network net2 (NAME)>
+net2IngressFIP: <FIP for net2 ingress (IPaddr)>
 net2IngressAllowedSources: ["0.0.0.0/0"]
 
 # A list of destinations that will be routed back towards the Primary Cluster network router.
-# These are implemented as neutron host routes on the Net2 subnet
+# These are implemented as neutron host routes on the Net2 subnet.
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud
@@ -40,10 +40,10 @@ net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
 
 # Disconnected install (usually needed for net2...)
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
-#   disconnected registry referenced in the imageContentSources block
-# - the entire imageContentSources: string should be indented by 2 spaces under the | as show in the example
+#   disconnected registry referenced in the imageContentSources block.
+# - the entire imageContentSources: string should be indented by 2 spaces under the | as show in the example.
 # - unless the private registry allows anonymous pull, the pull-secret.txt file should include an auth
-#   entry for the private registry
+#   entry for the private registry.
 disconnectedInstall: False
 installConfigExtraParams: |
   imageContentSources:

--- a/vars.yml
+++ b/vars.yml
@@ -15,10 +15,13 @@ neustarUltraDnsPassword: "password"
 
 # Net2 implements a second subnet for Net2 workers
 #  - it requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install
+#  - Net2 playbooks do not support Kuryr...
 #  - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in
 #    openshift-dns is installed on all nodes and the svc round-robins between them
-#  - externalDNSisOnNet2 defines whether the DNS servers are accessed via Net2 (by the whole cluster)
-#    or via the primary network
+#  - The cluster needs to be able to resolve its own external name (for oauth etc) and its OpenStack cloud API
+#    via the specified externalDNS
+#  - externalDNSisOnNet2 defines whether the externalDNS servers are accessed via Net2 (when set to True)
+#    or via the primary network (when set to False) - this applies to nodes on both networks!
 net2: False
 externalDNSisOnNet2: False 
 net2OspSubnet: <Subnet for net2 machines>
@@ -30,7 +33,7 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # These are implemented as neutron routes on the Net2 subnet
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
-# - API endpoint of OpenStack cloud
+# - IP of API endpoint of OpenStack cloud
 # (Routes for DNS servers do not need to be specified here; they are added automatically)
 # (Routes for comms to primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
@@ -38,9 +41,9 @@ net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
 # Disconnected install (usually needed for net2...)
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
 #   disconnected registry referenced in the imageContentSources block
-# - the entire imageContentSources: string should be indented by 2 space under the | as show in the example
-# - unless the private registry allows anonymous pull then the pull-secret.txt file should include an auth
-#   entry for it
+# - the entire imageContentSources: string should be indented by 2 spaces under the | as show in the example
+# - unless the private registry allows anonymous pull, the pull-secret.txt file should include an auth
+#   entry for the private registry
 disconnectedInstall: False
 installConfigExtraParams: |
   imageContentSources:

--- a/vars.yml
+++ b/vars.yml
@@ -3,8 +3,8 @@ externalNetwork: <Network cluster is on (NAME)>
 apiFIP: <FIP for controlplane (IPaddr)>
 ingressFIP: <FIP for dataplane (IPaddr)>
 bootstrapFIP: <FIP for bootstrap access (IPaddr)>
-custID: <Estate API ID for cluster>
-baseDomain: <Base domain for OSP region>
+custID: <Estate API ID for cluster (string)>
+baseDomain: <Base domain for OSP region (string)>
 rhcosImage: <rhcos image present in OSP project (NAME)>
 externalDNS: <List of 2 DNS servers (List of IPaddr)> 
 apiAllowedSources: ["0.0.0.0/0"]
@@ -36,7 +36,7 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # - IP of API endpoint of OpenStack cloud
 # (Routes for DNS servers do not need to be specified here; they are added automatically)
 # (Routes for comms to primary ospSubnet are also added automatically)
-net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
+net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 
 # Disconnected install (usually needed for net2...)
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 

--- a/vars.yml
+++ b/vars.yml
@@ -14,7 +14,7 @@ sshAllowedSources: <Add office IP, VPN IPs and internal network range in list fo
 neustarUltraDnsUsername: "username"
 neustarUltraDnsPassword: "password"
 
-net2: <boolean>
+net2: False
 net2OspSubnet: <Subnet for net2 machines>
 net2ExternalNetwork: <External Network net2>
 net2IngressFIP: <FIP for net2 ingress>
@@ -27,3 +27,19 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # - API endpoint of OpenStack cloud
 # (if necessary, automatic routes are added for DNS if externalDNSisNet2 is False)
 net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
+
+# Disconnected install (usually needed for net2...)
+# NOTE: 
+# - if disconnected, the openshift-install in the path needs to be custom for the specific 
+#   disconnected registry referenced in the imageContentSources block
+# - the entire imageContentSources: string should be between the double-quotes for installConfigExtraParams
+# - unless the private registry allows anonymous pull then the pull-secret.txt file should include an auth
+#   entry for it
+disconnectedInstall: False
+installConfigExtraParams: "imageContentSources:
+- mirrors:
+  - privateregistry.example.com/disconnectedpath
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - privateregistry.example.com/disconnectedpath
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev"

--- a/vars.yml
+++ b/vars.yml
@@ -56,7 +56,7 @@ net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 # SSH admin access from UKC office...
 # Alternatively, this could be used when Internet is Pri network to implement specific customer requirements
 # for all nodes to have access to some Net2 resources.
-net2RoutesViaNet2Network: []   # Proposed feature, not implemented
+priNetRoutesViaNet2Network: []   # Proposed feature, not implemented
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -37,7 +37,7 @@ net2ExternalNetwork: <External Network net2 (NAME)>
 net2IngressFIP: <FIP for net2 ingress (IPaddr)>
 net2IngressAllowedSources: ["0.0.0.0/0"]
 
-# A list of destinations that will be routed form Net2 subnet back towards the Primary Cluster network router.
+# A list of destinations that will be routed from Net2 subnet back towards the Primary Cluster network router.
 # These are implemented as neutron host routes on the Net2 subnet.
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)

--- a/vars.yml
+++ b/vars.yml
@@ -1,20 +1,26 @@
+custID: <Estate API ID for cluster (string)>
+baseDomain: <Base domain for OSP region (string)>
+rhcosImage: <rhcos image present in OSP project (NAME)>
+externalDNS: <List of exactly 2 DNS servers (List of IPaddr)> 
+
+# Primary network params
 ospSubnet: <Subnet for machines (CIDR)>
 externalNetwork: <Network cluster is on (NAME)>
 apiFIP: <FIP for controlplane (IPaddr)>
 ingressFIP: <FIP for dataplane (IPaddr)>
 bootstrapFIP: <FIP for bootstrap access (IPaddr)>
-custID: <Estate API ID for cluster (string)>
-baseDomain: <Base domain for OSP region (string)>
-rhcosImage: <rhcos image present in OSP project (NAME)>
-externalDNS: <List of 2 DNS servers (List of IPaddr)> 
 apiAllowedSources: ["0.0.0.0/0"]
 ingressAllowedSources: ["0.0.0.0/0"]
 sshAllowedSources: <Add office IP, VPN IPs and internal network range in list format (List of CIDR)>
+
+# Neustar account to allow DNS records to be created
 neustarUltraDnsUsername: "username"
 neustarUltraDnsPassword: "password"
 
+
+#################################################################################################################
 # Net2 implements a second subnet for Net2 workers.
-#  - it requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install.
+#  - it requires v4.7+, and (unless the net2 network has full Internet access) it needs disconnected install.
 #  - Net2 playbooks do not support Kuryr...
 #  - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in
 #    openshift-dns is installed on all nodes and the svc round-robins between them.
@@ -29,7 +35,7 @@ net2ExternalNetwork: <External Network net2 (NAME)>
 net2IngressFIP: <FIP for net2 ingress (IPaddr)>
 net2IngressAllowedSources: ["0.0.0.0/0"]
 
-# A list of destinations that will be routed back towards the Primary Cluster network router.
+# A list of destinations that will be routed form Net2 subnet back towards the Primary Cluster network router.
 # These are implemented as neutron host routes on the Net2 subnet.
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
@@ -38,25 +44,44 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # (Routes for comms to primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 
-# A list of destinations that the primary network can access via the Net2 network
+# A list of destinations that the primary network nodes can access via the Net2 network
 # This is mostly to enable a cluster whose primary network is NOT Internet, allowing
-# an API on a non-internet network
+# the API to be on a non-Internet network (when Internet is Net2)
 # If Internet is the Net2, it may be necessary to include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud
+# Special consideration (routing for sshAllowedSources) would need to be implemented to allow
+# SSH admin access from UKC office...
+# Alternatively, this could be used when Internet is Pri network to implement specific customer requirements
+# for all nodes to have access to some Net2 resources.
 net2RoutesViaNet2Network: []   # Proposed feature, not implemented
 
-# Extra Gateway - additional network connection and ingress on the primary network
-# If egIngressFIP is set to "", no Ingress will be created.
-extraGateway: False
-egIsOnNet2: False   # Proposed feature, not implemented
-egExternalNetwork: <External Network Extra Gateway (NAME)>
-egIngressFIP: <FIP for EG ingress (IPaddr)>
-egIngressAllowedSources: ["0.0.0.0/0"]
-egRoutes: <List of dests to route via Extra Gateway  (List of CIDR)>
-# If Net2 is also enabled, should EG outbound access be possible from Net2 workers?
-egAccessFromNet2: False   # Proposed feature, not implemented
 
+#################################################################################################################
+# Extra Gateway - a secondary network connection and ingress on the primary network (or maybe Net2 network?)
+# Should work fine with v4.6 (when Net2 isn't also enabled)
+# If egIngressFIP is set to "", no Ingress will be created and connectivity will be outbound-only
+# At this point, siting the cluster ExternalDNS on EG is not supported; routing would be made too complex?
+extraGateway: False
+egExternalNetwork: <External Network Extra Gateway (NAME)>
+egIngressFIP: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
+egIngressAllowedSources: ["0.0.0.0/0"]
+
+# Routes for EG that are added on the Primary network nodes via neutron subnet config
+# - if egIsOnNet2 is implemented&enabled, this will likely need router routes too?
+# - if egIsOnNet2 is implemented&enabled, and if EG access is not desired from Pri net, this should be set to []
+egRoutesonPriNetwork: <List of dests to route from Pri network to Extra Gateway  (List of CIDR)>
+
+# If Net2 is also enabled, Routes to be added to Net2 subnet to send towards EG 
+# - will likely need router routes too unless egIsOnNet2 is implemented&enabled
+# - if EG access is not desired from Net2, this should be set to []
+egRoutesonNet2Network: <List of dests to route from Net2 network to Extra Gateway (List of CIDR)>  # Proposed feature, not implemented
+
+# If Net2 is also enabled, Should Extra Gateway be attached to Net2 rather than the primary network? 
+egIsOnNet2: False   # Proposed feature, not implemented
+
+
+#################################################################################################################
 # Disconnected install (usually needed for net2...)
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
 #   disconnected registry referenced in the imageContentSources block.

--- a/vars.yml
+++ b/vars.yml
@@ -38,6 +38,25 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # (Routes for comms to primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 
+# A list of destinations that the primary network can access via the Net2 network
+# This is mostly to enable a cluster whose primary network is NOT Internet, allowing
+# an API on a non-internet network
+# If Internet is the Net2, it may be necessary to include:
+# - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
+# - IP of API endpoint of OpenStack cloud
+net2RoutesViaNet2Network: []   # Proposed feature, not implemented
+
+# Extra Gateway - additional network connection and ingress on the primary network
+# If egIngressFIP is set to "", no Ingress will be created.
+extraGateway: False
+egIsOnNet2: False   # Proposed feature, not implemented
+egExternalNetwork: <External Network Extra Gateway (NAME)>
+egIngressFIP: <FIP for EG ingress (IPaddr)>
+egIngressAllowedSources: ["0.0.0.0/0"]
+egRoutes: <List of dests to route via Extra Gateway  (List of CIDR)>
+# If Net2 is also enabled, should EG outbound access be possible from Net2 workers?
+egAccessFromNet2: False   # Proposed feature, not implemented
+
 # Disconnected install (usually needed for net2...)
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
 #   disconnected registry referenced in the imageContentSources block.

--- a/vars.yml
+++ b/vars.yml
@@ -34,7 +34,7 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud
-# (Routes for DNS servers do not need to be specified here; they are added automatically)
+# (Routes for DNS servers do not need to be specified here; they are added automatically where appropriate)
 # (Routes for comms to primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 

--- a/vars.yml
+++ b/vars.yml
@@ -63,25 +63,14 @@ priNetRoutesViaNet2Network: []   # Proposed feature, not implemented
 # Extra Gateway on Primary network - a secondary network connection and ingress on the primary network 
 # Should work fine with v4.6
 # At this point, siting the cluster ExternalDNS on EG is not supported; routing would be made too complex?
-extraGatewayForPriNet: False
-egExternalNetworkForPriNet: <External Network Extra Gateway (NAME)>
-egIngressFIPForPriNet: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
-egIngressAllowedSourcesForPriNet: ["0.0.0.0/0"]
+extraGateway: False
+egExternalNetwork: <External Network Extra Gateway (NAME)>
+egIngressFIP: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
+egIngressAllowedSources: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Primary network nodes via neutron subnet config
 # Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
-egRoutesonPriNetwork: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
-
-# Extra Gateway on Net2 - a secondary network connection and ingress on the Net2 network 
-# Net2 must also be enabled
-extraGatewayForNet2: False    # Proposed feature, not implemented
-egExternalNetworkForNet2: <External Network Extra Gateway (NAME)>
-egIngressFIPForNet2: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
-egIngressAllowedSourcesForNet2: ["0.0.0.0/0"]
-
-# Routes for EG that are added on the Net2 nodes via neutron subnet config
-# Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
-egRoutesonNet2Network: <List of dests to route from Net2 network to its Extra Gateway (List of CIDR)>  # Proposed feature, not implemented
+egRoutes: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -70,7 +70,14 @@ egIngressAllowedSources: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Primary network nodes via neutron subnet config
 # Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
-egRoutes: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
+egRoutesOnPriNetwork: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
+
+# List of destinations on EG that should be accessible from Net2 network, via routes which are added automatically 
+# as follows (possibly identical to egRoutesOnPriNetwork if that is the requirement):
+# - Routes added to Net2 subnet to send traffic to Pri router
+# - Routes on the Pri router to send these dests toward the EG router
+# - A return route for the whole Net2 subnet on the EG router, sending replies back to the Pri router 
+egRoutesOnNet2Network: []    # Proposed feature, not implemented
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -69,19 +69,19 @@ egIngressFIPForPriNet: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
 egIngressAllowedSourcesForPriNet: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Primary network nodes via neutron subnet config
+# Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
 egRoutesonPriNetwork: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
 
-
 # Extra Gateway on Net2 - a secondary network connection and ingress on the Net2 network 
-# Net2 muyst also be enabled
+# Net2 must also be enabled
 extraGatewayForNet2: False    # Proposed feature, not implemented
-egExternalNetworkiForNet2: <External Network Extra Gateway (NAME)>
+egExternalNetworkForNet2: <External Network Extra Gateway (NAME)>
 egIngressFIPForNet2: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
 egIngressAllowedSourcesForNet2: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Net2 nodes via neutron subnet config
+# Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
 egRoutesonNet2Network: <List of dests to route from Net2 network to its Extra Gateway (List of CIDR)>  # Proposed feature, not implemented
-
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -56,7 +56,7 @@ net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 # SSH admin access from UKC office...
 # Alternatively, this could be used when Internet is Pri network to implement specific customer requirements
 # for all nodes to have access to some Net2 resources.
-priNetRoutesViaNet2Network: []   # Proposed feature, not implemented
+priNetRoutesViaNet2Network: []    # <List of dests to route (List of CIDR)>
 
 
 #################################################################################################################
@@ -70,14 +70,14 @@ egIngressAllowedSources: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Primary network nodes via neutron subnet config
 # Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
-egRoutesOnPriNetwork: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
+egRoutesOnPriNetwork: []    # <List of dests to route from Pri network to Extra Gateway  (List of CIDR)>
 
 # List of destinations on EG that should be accessible from Net2 network, via routes which are added automatically 
 # as follows (possibly identical to egRoutesOnPriNetwork if that is the requirement):
 # - Routes added to Net2 subnet to send traffic to Pri router
 # - Routes on the Pri router to send these dests toward the EG router
 # - A return route for the whole Net2 subnet on the EG router, sending replies back to the Pri router 
-egRoutesOnNet2Network: []    # Proposed feature, not implemented
+egRoutesOnNet2Network: []   # <List of dests to route from Neyt2 network to Extra Gateway  (List of CIDR)>
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -30,7 +30,7 @@ net2IngressFIP: <FIP for net2 ingress>
 net2IngressAllowedSources: ["0.0.0.0/0"]
 
 # A list of destinations that will be routed back towards the Primary Cluster network router.
-# These are implemented as neutron routes on the Net2 subnet
+# These are implemented as neutron host routes on the Net2 subnet
 # Should include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud

--- a/vars.yml
+++ b/vars.yml
@@ -4,6 +4,9 @@ rhcosImage: <rhcos image present in OSP project (NAME)>
 externalDNS: <List of exactly 2 DNS servers (List of IPaddr)> 
 initialWorkerCount: 2
 
+# OpenShift SDN network ranges can be altered using osClusterNetwork and osServiceNetwork parameters 
+# for complex network situations but usually don't need to be specifed
+
 # Primary network params
 ospSubnet: <Subnet for machines (CIDR)>
 externalNetwork: <Network cluster is on (NAME)>

--- a/vars.yml
+++ b/vars.yml
@@ -4,9 +4,6 @@ rhcosImage: <rhcos image present in OSP project (NAME)>
 externalDNS: <List of exactly 2 DNS servers (List of IPaddr)> 
 initialWorkerCount: 2
 
-# OpenShift SDN network ranges can be altered using osClusterNetwork and osServiceNetwork parameters 
-# for complex network situations but usually don't need to be specifed
-
 # Primary network params
 ospSubnet: <Subnet for machines (CIDR)>
 externalNetwork: <Network cluster is on (NAME)>
@@ -21,17 +18,20 @@ sshAllowedSources: <Add office IP, VPN IPs and internal network range in list fo
 neustarUltraDnsUsername: "username"
 neustarUltraDnsPassword: "password"
 
+# Default OpenShift SDN network ranges can be altered by adding osClusterNetwork and osServiceNetwork parameters 
+#  for complex network situations but these usually don't need to be specifed.
+
 
 #################################################################################################################
 # Net2 implements a second subnet for Net2 workers.
-#  - it requires v4.7+, and (unless the net2 network has full Internet access) it needs disconnected install.
+#  - Net2 requires v4.7+, and (unless the net2 network has full Internet access) it needs disconnected install.
 #  - Net2 playbooks do not support Kuryr...
 #  - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in
 #    openshift-dns is installed on all nodes and the svc round-robins between them.
 #  - The cluster needs to be able to resolve its own external name (for oauth etc) and its OpenStack cloud API
 #    via the specified externalDNS.
 #  - "externalDNSisOnNet2" defines whether the externalDNS servers are accessed via Net2 (when set to True)
-#    or via the primary network (when set to False) - this applies to nodes on both networks!
+#    or via the primary network (when set to False).
 net2: False
 externalDNSisOnNet2: False 
 net2InitialWorkerCount: 2
@@ -46,26 +46,28 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud
 # (Routes for DNS servers do not need to be specified here; they are added automatically where appropriate)
-# (Routes for comms to primary ospSubnet are also added automatically)
+# (Routes for comms to controlplane on primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
 
-# A list of destinations that the primary network nodes can access via the Net2 network
+# A list of destinations that the primary network nodes can access via the Net2 network.
 # This is mostly to enable a cluster whose primary network is NOT Internet, allowing
-# the API to be on a non-Internet network (when Internet is Net2)
+#  the API to be on a non-Internet network (when Internet is Net2).
 # If Internet is the Net2, it may be necessary to include:
 # - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - IP of API endpoint of OpenStack cloud
 # Special consideration (routing for sshAllowedSources) would need to be implemented to allow
-# SSH admin access from UKC office...
+#  SSH admin access from UKC office...
 # Alternatively, this could be used when Internet is Pri network to implement specific customer requirements
-# for all nodes to have access to some Net2 resources.
+#  for all nodes to have access to some Net2 resources.
 priNetRoutesViaNet2Network: []    # <List of dests to route (List of CIDR)>
 
 
 #################################################################################################################
 # Extra Gateway on Primary network - a secondary network connection and ingress on the primary network 
-# Should work fine with v4.6
+# Should work fine with v4.6 (unless Net2 is also enabled)
 # At this point, siting the cluster ExternalDNS on EG is not supported; routing would be made too complex?
+# However, private DNS servers that will be used in zone forwards should be accessible via a CIDR specified in 
+#  both egRoutesOnPriNetwork (and egRoutesOnNet2Network when Net2 is also enabled)
 extraGateway: False
 egExternalNetwork: <External Network Extra Gateway (NAME)>
 egIngressFIP: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
@@ -75,12 +77,12 @@ egIngressAllowedSources: ["0.0.0.0/0"]
 # Note: these routes must include any client IPs that are to access egIngressFIP from the egExternalNetwork
 egRoutesOnPriNetwork: []    # <List of dests to route from Pri network to Extra Gateway  (List of CIDR)>
 
-# List of destinations on EG that should be accessible from Net2 network, via routes which are added automatically 
-# as follows (possibly identical to egRoutesOnPriNetwork if that is the requirement):
+# List of destinations on EG that should be accessible from Net2 nodes, via routes which are added automatically 
+#  as follows (possibly identical to egRoutesOnPriNetwork if that is the requirement):
 # - Routes added to Net2 subnet to send traffic to Pri router
 # - Routes on the Pri router to send these dests toward the EG router
 # - A return route for the whole Net2 subnet on the EG router, sending replies back to the Pri router 
-egRoutesOnNet2Network: []   # <List of dests to route from Neyt2 network to Extra Gateway  (List of CIDR)>
+egRoutesOnNet2Network: []   # <List of dests to route from Net2 network to Extra Gateway  (List of CIDR)>
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -47,7 +47,7 @@ net2IngressAllowedSources: ["0.0.0.0/0"]
 # - IP of API endpoint of OpenStack cloud
 # (Routes for DNS servers do not need to be specified here; they are added automatically where appropriate)
 # (Routes for comms to controlplane on primary ospSubnet are also added automatically)
-net2RoutesViaPriNetwork: <List of dests to route (List of CIDR)>
+net2RoutesViaPriNetwork: [] # <List of dests to route (List of CIDR)>
 
 # A list of destinations that the primary network nodes can access via the Net2 network.
 # This is mostly to enable a cluster whose primary network is NOT Internet, allowing

--- a/vars.yml
+++ b/vars.yml
@@ -61,7 +61,7 @@ priNetRoutesViaNet2Network: []   # Proposed feature, not implemented
 
 #################################################################################################################
 # Extra Gateway on Primary network - a secondary network connection and ingress on the primary network 
-# Should work fine with v4.6 (when Net2 isn't also enabled)
+# Should work fine with v4.6
 # At this point, siting the cluster ExternalDNS on EG is not supported; routing would be made too complex?
 extraGatewayForPriNet: False
 egExternalNetworkForPriNet: <External Network Extra Gateway (NAME)>

--- a/vars.yml
+++ b/vars.yml
@@ -60,27 +60,28 @@ net2RoutesViaNet2Network: []   # Proposed feature, not implemented
 
 
 #################################################################################################################
-# Extra Gateway - a secondary network connection and ingress on the primary network (or maybe Net2 network?)
+# Extra Gateway on Primary network - a secondary network connection and ingress on the primary network 
 # Should work fine with v4.6 (when Net2 isn't also enabled)
-# If egIngressFIP is set to "", no Ingress will be created and connectivity will be outbound-only
 # At this point, siting the cluster ExternalDNS on EG is not supported; routing would be made too complex?
-extraGateway: False
-egExternalNetwork: <External Network Extra Gateway (NAME)>
-egIngressFIP: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
-egIngressAllowedSources: ["0.0.0.0/0"]
+extraGatewayForPriNet: False
+egExternalNetworkForPriNet: <External Network Extra Gateway (NAME)>
+egIngressFIPForPriNet: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
+egIngressAllowedSourcesForPriNet: ["0.0.0.0/0"]
 
 # Routes for EG that are added on the Primary network nodes via neutron subnet config
-# - if egIsOnNet2 is implemented&enabled, this will likely need router routes too?
-# - if egIsOnNet2 is implemented&enabled, and if EG access is not desired from Pri net, this should be set to []
-egRoutesonPriNetwork: <List of dests to route from Pri network to Extra Gateway  (List of CIDR)>
+egRoutesonPriNetwork: <List of dests to route from Pri network to its Extra Gateway  (List of CIDR)>
 
-# If Net2 is also enabled, Routes to be added to Net2 subnet to send towards EG 
-# - will likely need router routes too unless egIsOnNet2 is implemented&enabled
-# - if EG access is not desired from Net2, this should be set to []
-egRoutesonNet2Network: <List of dests to route from Net2 network to Extra Gateway (List of CIDR)>  # Proposed feature, not implemented
 
-# If Net2 is also enabled, Should Extra Gateway be attached to Net2 rather than the primary network? 
-egIsOnNet2: False   # Proposed feature, not implemented
+# Extra Gateway on Net2 - a secondary network connection and ingress on the Net2 network 
+# Net2 muyst also be enabled
+extraGatewayForNet2: False    # Proposed feature, not implemented
+egExternalNetworkiForNet2: <External Network Extra Gateway (NAME)>
+egIngressFIPForNet2: <FIP for EG ingress (IPaddr) or "" to disable EG ingress>
+egIngressAllowedSourcesForNet2: ["0.0.0.0/0"]
+
+# Routes for EG that are added on the Net2 nodes via neutron subnet config
+egRoutesonNet2Network: <List of dests to route from Net2 network to its Extra Gateway (List of CIDR)>  # Proposed feature, not implemented
+
 
 
 #################################################################################################################

--- a/vars.yml
+++ b/vars.yml
@@ -7,29 +7,35 @@ custID: <Estate API ID for cluster>
 baseDomain: <Base domain for OSP region>
 rhcosImage: <rhcos image present in OSP project>
 externalDNS: <List of 2 DNS servers> 
-externalDNSisOnNet2: False 
 apiAllowedSources: ["0.0.0.0/0"]
 ingressAllowedSources: ["0.0.0.0/0"]
 sshAllowedSources: <Add office IP, VPN IPs and internal network range in list format>
 neustarUltraDnsUsername: "username"
 neustarUltraDnsPassword: "password"
 
+# Net2 implements a second subnet for Net2 workers
+#  - it requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install
+#  - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in
+#    openshift-dns is installed on all nodes and the svc round-robins between them
+#  - externalDNSisOnNet2 defines whether the DNS servers are accessed via Net2 (by the whole cluster)
+#    or via the primary network
 net2: False
+externalDNSisOnNet2: False 
 net2OspSubnet: <Subnet for net2 machines>
 net2ExternalNetwork: <External Network net2>
 net2IngressFIP: <FIP for net2 ingress>
 net2IngressAllowedSources: ["0.0.0.0/0"]
 
-# A list of destinations that will be routed back towards the Primary Cluster network router;
+# A list of destinations that will be routed back towards the Primary Cluster network router.
 # These are implemented as neutron routes on the Net2 subnet
 # Should include:
-# - IP of disconnected installation registry (include any ECS/S3 endpoint IP it uses)
+# - IP of disconnected installation registry (plus any ECS/S3 endpoint IP it uses)
 # - API endpoint of OpenStack cloud
-# (if necessary, automatic routes are added for DNS if externalDNSisNet2 is False)
+# (Routes for DNS servers do not need to be specified here; they are added automatically)
+# (Routes for comms to primary ospSubnet are also added automatically)
 net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
 
 # Disconnected install (usually needed for net2...)
-# NOTE: 
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
 #   disconnected registry referenced in the imageContentSources block
 # - the entire imageContentSources: string should be indented by 2 space under the | as show in the example

--- a/vars.yml
+++ b/vars.yml
@@ -32,14 +32,15 @@ net2RoutesViaPriNetwork: ["1.2.3.4/32", "5.6.7.8/32"]
 # NOTE: 
 # - if disconnected, the openshift-install in the path needs to be custom for the specific 
 #   disconnected registry referenced in the imageContentSources block
-# - the entire imageContentSources: string should be between the double-quotes for installConfigExtraParams
+# - the entire imageContentSources: string should be indented by 2 space under the | as show in the example
 # - unless the private registry allows anonymous pull then the pull-secret.txt file should include an auth
 #   entry for it
 disconnectedInstall: False
-installConfigExtraParams: "imageContentSources:
-- mirrors:
-  - privateregistry.example.com/disconnectedpath
-  source: quay.io/openshift-release-dev/ocp-release
-- mirrors:
-  - privateregistry.example.com/disconnectedpath
-  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+installConfigExtraParams: |
+  imageContentSources:
+  - mirrors:
+    - privateregistry.example.com/disconnectedpath
+    source: quay.io/openshift-release-dev/ocp-release
+  - mirrors:
+    - privateregistry.example.com/disconnectedpath
+    source: quay.io/openshift-release-dev/ocp-v4.0-art-dev


### PR DESCRIPTION
### Design docs on Confluence

Implements a second subnet for Net2 workers.
 - Net2 requires v4.7+ and (unless the net2 network has Internet access) it needs disconnected install.
 - Net2 playbooks do not support Kuryr...
 - Currently, the whole cluster needs to use the same DNS servers (because dns daemonset in openshift-dns is installed on all nodes and the svc round-robins between them).
 - The cluster needs to be able to resolve its own external name (for oauth etc) and its OpenStack cloud API via the specified externalDNS.
 - "externalDNSisOnNet2" `vars.yml` setting defines whether the externalDNS servers are accessed via Net2 (when set to True) or via the primary network (when set to False) - this applies to nodes on both networks!
 - Code creates a net2 server group and machinesets.

Also implements Disconnected install (usually needed for net2...)
- if disconnected, the `openshift-install` binary in the shell path or bin dir for the python venv needs to be custom for the specific disconnected registry referenced in the imageContentSources block.
- the entire imageContentSources: string should be indented by 2 spaces under the | as shown in the example `vars.yml`.
- unless the private registry allows anonymous pull, the `pull-secret.txt` file should include an auth entry for the private registry.

Also implements Extragateway on Primary network, along with routes to optionally allow Net2 workers (when Net2 is enabled) to access endpoints on EG.

Code also makes some changes to `down_*` playbooks so that net2/eg resources are usually removed, primarily to make testing easier. 

### More work needed...
- Parametrise the default computeFlavor used for nodes.
- Post-deploy (in other repo?) to implement Ingress etc. Should post-deployment be driven by the same `vars.yml` maybe?
- Deployment code for HAProxy VMs if that is the selected Net2/EG ingress method.
- Cut down on unnecessary security group rules (problem for net2 and non-net2 ...)
- Improve the down playbooks so they always work.
- Move infra MachineSet from post-deployment into manifest mangling in this code, to match what is done with net2 and initial worker MachineSet (and to ensure the correct Server group is applied to it).
...

