### PR TITLE
Parameterise flavors and set nodenames

### DIFF
--- a/manifests.yaml
+++ b/manifests.yaml
@@ -34,7 +34,7 @@
       regexp: '^\s{2}mastersSchedulable: true$'
       replace: '  mastersSchedulable: False'
 
-  - name: Include vars from worker machinset to obtain cluster ID (not available from metadata.json cos it aint been generated yet)
+  - name: Include vars from worker machineset to obtain cluster ID (not available from metadata.json cos it aint been generated yet)
     include_vars:
       file: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
       name: machineSetData      

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -34,6 +34,11 @@
       regexp: '^\s{2}mastersSchedulable: true$'
       replace: '  mastersSchedulable: False'
 
+  - name: Include vars from worker machinset to obtain cluster ID (not available from metadata.json cos it aint been generated yet)
+    include_vars:
+      file: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      name: machineSetData      
+
 
 - import_playbook: net2-manifests.yaml
   when: net2 | default(false) | bool
@@ -58,6 +63,18 @@
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
       regexp: '^\s{2}replicas: 0$'
       replace: '  replicas: {{ initialWorkerCount }}'
+
+  - name: Find/replace MachineSet Name
+    replace:
+        path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+        regexp: "{{ machineSetData.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}-worker-0"
+        replace: "{{ ( custID + '-' + workerFlavor ) | replace('.','-') | replace('ocp-','') | replace('app-','') }}-worker"
+
+  - name: Find/replace serverMetadata Name
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+        regexp: "Name: {{ machineSetData.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}-worker"
+        replace: "Name: {{ ( custID + '-' + workerFlavor ) | replace('.','-') | replace('ocp-','') | replace('app-','') }}-worker"
 
   - name: Generate ignition configs
     command: openshift-install create ignition-configs --dir=./

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -72,7 +72,7 @@
 
   - name: Find/replace serverMetadata Name
     replace:
-        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+        path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
         regexp: "Name: {{ machineSetData.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}-worker"
         replace: "Name: {{ ( custID + '-' + workerFlavor ) | replace('.','-') | replace('ocp-','') | replace('app-','') }}-worker"
 

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -21,7 +21,14 @@
     replace:
       path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
       regexp: '^\s{2}replicas: 0$'
-      replace: '  replicas: {{ net2InitialWorkerCount }}'
+      replace: '  replicas: {{ net2InitialWorkerCount | default (0) }}'
+
+  - name: Find/replace worker flavor
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml    
+        regexp: "flavor: {{ workerFlavor }}"
+        replace: "flavor: {{ net2WorkerFlavor }}"
+    when: net2WorkerFlavor is defined and net2WorkerFlavor|length>0
 
   - name: Find/replace MachineSet, server and security group name
     replace:

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -36,6 +36,18 @@
         regexp: "-worker"
         replace: "-net2-worker"
 
+  - name: Find/replace MachineSet Name
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml    
+        regexp: "{{ machineSetData.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}-net2-worker-0"
+        replace: "{{ ( custID + '-' + net2WorkerFlavor ) | replace('.','-') | replace('ocp-','') | replace('app-','') }}-net2-worker"
+
+  - name: Find/replace serverMetadata Name
+    replace:
+        path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml    
+        regexp: "Name: {{ machineSetData.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}-net2-worker"
+        replace: "Name: {{ ( custID + '-' + net2WorkerFlavor ) | replace('.','-') | replace('ocp-','') | replace('app-','') }}-net2-worker"
+
   - name: Find/replace subnet name
     replace:
         path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml

--- a/templates/install-config.j2
+++ b/templates/install-config.j2
@@ -4,13 +4,17 @@ compute:
 - architecture: amd64
   hyperthreading: Enabled
   name: worker
-  platform: {}
+  platform:
+    openstack:
+      type: {{ workerFlavor }}
   replicas: 0
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
   name: controlplane
-  platform: {}
+  platform: 
+    openstack:
+      type: {{ controlplaneFlavor }}
   replicas: 3
 metadata:
   creationTimestamp: null
@@ -28,7 +32,6 @@ platform:
   openstack:
     apiVIP: {{ os_apiVIP }}
     cloud: openstack
-    computeFlavor: ocp.m1.medium
     clusterOSImage: {{ rhcosImage }}
     externalDNS:
 {% for dnsServer in externalDNS %}

--- a/vars.yml
+++ b/vars.yml
@@ -2,6 +2,8 @@ custID: <Estate API ID for cluster (string)>
 baseDomain: <Base domain for OSP region (string)>
 rhcosImage: <rhcos image present in OSP project (NAME)>
 externalDNS: <List of exactly 2 DNS servers (List of IPaddr)> 
+controlplaneFlavor: ocp.m1.medium # <OpenStack Flavor (NAME)>
+workerFlavor: ocp.t1.xxlarge # <OpenStack Flavor (NAME)>
 initialWorkerCount: 2
 
 # Primary network params
@@ -34,6 +36,7 @@ neustarUltraDnsPassword: "password"
 #    or via the primary network (when set to False).
 net2: False
 externalDNSisOnNet2: False 
+net2WorkerFlavor: ocp.t1.xxlarge # <OpenStack Flavor (NAME)>
 net2InitialWorkerCount: 2
 net2OspSubnet: <Subnet for net2 machines (CIDR)>
 net2ExternalNetwork: <External Network net2 (NAME)>


### PR DESCRIPTION
This allows controlplane, worker and net2worker flavors to be set in `vars.yml`

Also, sets worker node names to be `<custID>-<flavor>-worker-NONCE` and `<custID>-<flavor>-net2-worker-NONCE`

The methods of modifying the MachineSets remain unpleasant but I have trouble thinking of better alternatives.