### PR TITLE
Anonymise SSH key comment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-ssh-keygen -t rsa -b 4096 -N '' -f openshift_key
+ssh-keygen -t ed25519 -N '' -f openshift_key -C "$(date +%d-%m-%y)"
 
 cp openshift_key.pub files/pubkey.pem
 


### PR DESCRIPTION
Uses date of deployment to minimise information leakage while allowing keys to be differentiated.

Switches to use ed25519 keys since Red Hat has backported that recommendation all the way back to RHCOS 4.4