### PR TITLE
Restrict sources via EG and net2 ingresses

### DIFF
--- a/eg-ingress.yaml
+++ b/eg-ingress.yaml
@@ -42,6 +42,13 @@
       protocol_port: "{{ item.port }}"
     with_items: "{{ protocols }}"
 
+  - name: 'Restrict listener to ingress allowed sources'
+    command:
+      cmd: "openstack loadbalancer listener set {% for cidr in egIngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
+    loop: "{{ protocols }}"
+    loop_control:
+      pause: 10
+
   - name: 'Create pools'
     openstack.cloud.lb_pool:
       name: "{{ os_eg_ingress_lb }}-{{ item.protocol }}-pool"

--- a/eg-ingress.yaml
+++ b/eg-ingress.yaml
@@ -42,13 +42,6 @@
       protocol_port: "{{ item.port }}"
     with_items: "{{ protocols }}"
 
-  - name: 'Restrict listener to ingress allowed sources'
-    command:
-      cmd: "openstack loadbalancer listener set {% for cidr in egIngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
-    loop: "{{ protocols }}"
-    loop_control:
-      pause: 10
-
   - name: 'Create pools'
     openstack.cloud.lb_pool:
       name: "{{ os_eg_ingress_lb }}-{{ item.protocol }}-pool"
@@ -69,3 +62,10 @@
       max_retries: "3"
       resp_timeout: "5"
     with_items: "{{ protocols }}"
+
+  - name: 'Restrict listener to ingress allowed sources'
+    command:
+      cmd: "openstack loadbalancer listener set {% for cidr in egIngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
+    loop: "{{ protocols }}"
+    loop_control:
+      pause: 10

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -21,22 +21,20 @@
       cmd: "openstack security group set --tag {{ cluster_id_tag }} {{ os_eg_sg_ingress }} "
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
 
-  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP external"'
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
-      remote_ip_prefix: "{{ item }}"
+      remote_ip_prefix: "{{ os_eg_ingressVIP }}"
       protocol: tcp
       port_range_min: 30080
       port_range_max: 30080
-    loop: "{{ egIngressAllowedSources }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
 
-  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS external"'
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
-      remote_ip_prefix: "{{ item }}"
+      remote_ip_prefix: "{{ os_eg_ingressVIP }}"
       protocol: tcp
       port_range_min: 30443
       port_range_max: 30443
-    loop: "{{ egIngressAllowedSources }}"
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -21,7 +21,7 @@
       cmd: "openstack security group set --tag {{ cluster_id_tag }} {{ os_eg_sg_ingress }} "
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0
 
-  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP loadbalancer"'
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
       remote_ip_prefix: "{{ os_subnet_range }}"
@@ -30,7 +30,7 @@
       port_range_max: 30080
     when: os_eg_ingress_fip is defined and os_eg_ingress_fip|length>0    
 
-  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS loadbalancer"'
+  - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
       remote_ip_prefix: "{{ os_subnet_range }}"

--- a/eg-security-groups.yaml
+++ b/eg-security-groups.yaml
@@ -24,7 +24,7 @@
   - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTP loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
-      remote_ip_prefix: "{{ os_eg_ingressVIP }}"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       protocol: tcp
       port_range_min: 30080
       port_range_max: 30080
@@ -33,7 +33,7 @@
   - name: 'Create eg-ingress-sg rule "Extra Gateway Ingress HTTPS loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_eg_sg_ingress }}"
-      remote_ip_prefix: "{{ os_eg_ingressVIP }}"
+      remote_ip_prefix: "{{ os_subnet_range }}"
       protocol: tcp
       port_range_min: 30443
       port_range_max: 30443

--- a/net2-ingress.yaml
+++ b/net2-ingress.yaml
@@ -42,13 +42,6 @@
       protocol_port: "{{ item.port }}"
     with_items: "{{ protocols }}"
 
-  - name: 'Restrict listener to ingress allowed sources'
-    command:
-      cmd: "openstack loadbalancer listener set {% for cidr in net2IngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
-    loop: "{{ protocols }}"
-    loop_control:
-      pause: 10
-
   - name: 'Create pools'
     openstack.cloud.lb_pool:
       name: "{{ os_net2_ingress_lb }}-{{ item.protocol }}-pool"
@@ -69,3 +62,10 @@
       max_retries: "3"
       resp_timeout: "5"
     with_items: "{{ protocols }}"
+
+  - name: 'Restrict listener to ingress allowed sources'
+    command:
+      cmd: "openstack loadbalancer listener set {% for cidr in net2IngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
+    loop: "{{ protocols }}"
+    loop_control:
+      pause: 10

--- a/net2-ingress.yaml
+++ b/net2-ingress.yaml
@@ -42,6 +42,13 @@
       protocol_port: "{{ item.port }}"
     with_items: "{{ protocols }}"
 
+  - name: 'Restrict listener to ingress allowed sources'
+    command:
+      cmd: "openstack loadbalancer listener set {% for cidr in net2IngressAllowedSources %} --allowed-cidr {{ cidr }} {% endfor %} {{ os_eg_ingress_lb }}-{{ item.protocol }}-listener"
+    loop: "{{ protocols }}"
+    loop_control:
+      pause: 10
+
   - name: 'Create pools'
     openstack.cloud.lb_pool:
       name: "{{ os_net2_ingress_lb }}-{{ item.protocol }}-pool"

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -490,19 +490,3 @@
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
-
-  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTP loadbalancer"'
-    os_security_group_rule:
-      security_group: "{{ os_net2_sg_ingress }}"
-      remote_ip_prefix: "{{ os_net2_ingressVIP }}"
-      protocol: tcp
-      port_range_min: 80
-      port_range_max: 80
-
-  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTPS loadbalancer"'
-    os_security_group_rule:
-      security_group: "{{ os_net2_sg_ingress }}"
-      remote_ip_prefix: "{{ os_net2_ingressVIP }}"
-      protocol: tcp
-      port_range_min: 443
-      port_range_max: 443

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -475,7 +475,7 @@
       port_range_min: 6443
       port_range_max: 6443
 
-  - name: 'Create net2-ingress-sg rule "Ingress HTTP"'
+  - name: 'Create net2-ingress-sg rule "net2 Ingress HTTP"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
       remote_ip_prefix: "{{ os_net2_subnet_range }}"
@@ -483,7 +483,7 @@
       port_range_min: 80
       port_range_max: 80
 
-  - name: 'Create net2-ingress-sg rule "Ingress HTTPS"'
+  - name: 'Create net2-ingress-sg rule "net2 Ingress HTTPS"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
       remote_ip_prefix: "{{ os_net2_subnet_range }}"

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -491,20 +491,18 @@
       port_range_min: 443
       port_range_max: 443
 
-  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTP external"'
+  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTP loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
-      remote_ip_prefix: "{{ item }}"
+      remote_ip_prefix: "{{ os_net2_ingressVIP }}"
       protocol: tcp
       port_range_min: 80
       port_range_max: 80
-    loop: "{{ net2IngressAllowedSources }}"
 
-  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTPS external"'
+  - name: 'Create net2-ingress-sg rule "Net2 Ingress HTTPS loadbalancer"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
-      remote_ip_prefix: "{{ item }}"
+      remote_ip_prefix: "{{ os_net2_ingressVIP }}"
       protocol: tcp
       port_range_min: 443
       port_range_max: 443
-    loop: "{{ net2IngressAllowedSources }}"

--- a/net2-security-groups.yaml
+++ b/net2-security-groups.yaml
@@ -475,7 +475,7 @@
       port_range_min: 6443
       port_range_max: 6443
 
-  - name: 'Create net2-ingress-sg rule "Ingress HTTP internal"'
+  - name: 'Create net2-ingress-sg rule "Ingress HTTP"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
       remote_ip_prefix: "{{ os_net2_subnet_range }}"
@@ -483,7 +483,7 @@
       port_range_min: 80
       port_range_max: 80
 
-  - name: 'Create net2-ingress-sg rule "Ingress HTTPS internal"'
+  - name: 'Create net2-ingress-sg rule "Ingress HTTPS"'
     os_security_group_rule:
       security_group: "{{ os_net2_sg_ingress }}"
       remote_ip_prefix: "{{ os_net2_subnet_range }}"

--- a/templates/infra-machineset.j2
+++ b/templates/infra-machineset.j2
@@ -54,6 +54,10 @@ spec:
           - filter: {}
             name: "{{ clusterID }}-ingress-pingdom"
 {% endif %}
+{% if (extraGateway | default(false) | bool) %}
+          - filter: {}
+            name: "{{ clusterID }}-eg-ingress"
+{% endif %}
           serverMetadata:
             Name: "{{ clusterID }}-infra"
             openshiftClusterID: "{{ clusterID }}"
@@ -62,4 +66,3 @@ spec:
           trunk: true
           userDataSecret:
             name: infra-user-data
-


### PR DESCRIPTION
Set allowed-cidr option against Octavia loadbalancers to restrict ingress from alternative networks, additionally clean up ingress security group rules.