### PR TITLE
Fix pip-requirements

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -4,5 +4,5 @@ openstacksdk>=0.59.0
 python-openstackclient>=5.6.0
 python-octaviaclient>=2.4.0
 jmespath>=0.10.0
-openshift>=0.11.2
+openshift~=0.11.2
 PyYAML>=5.3.1


### PR DESCRIPTION
openshift client v12 still errors such as 
```
"Failed to get client due to HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x>: Failed to establish a new connection: [Errno 61] Connection refused'))"
```

So we need to stick will v11