### PR TITLE
Add custID to server group names 

### DIFF
--- a/down-server-groups.yaml
+++ b/down-server-groups.yaml
@@ -5,12 +5,12 @@
       state: absent
       name: "{{ item }}"
     loop:
-    - "worker-default"
-    - "infra"
-    - "controlplane"
+    - "{{ custID }}-worker-default"
+    - "{{ custID }}-infra"
+    - "{{ custID }}-controlplane"
 
   - name: Remove net2 server group
     openstack.cloud.server_group:
       state: absent
-      name: "worker-net2"
+      name: "{{ custID }}-worker-net2"
     when: net2 | default(false) | bool

--- a/server-groups.yaml
+++ b/server-groups.yaml
@@ -3,7 +3,7 @@
   - name: Create default worker server group
     openstack.cloud.server_group:
       state: present
-      name: worker-default
+      name: "{{ custID }}-worker-default"
       policies:
       - soft-anti-affinity
     register: workerDefault
@@ -11,7 +11,7 @@
   - name: Create infra server group
     openstack.cloud.server_group:
       state: present
-      name: infra
+      name: "{{ custID }}-infra"
       policies:
       - anti-affinity
     register: infraGroup
@@ -19,7 +19,7 @@
   - name: Create controlplane server group
     openstack.cloud.server_group:
       state: present
-      name: controlplane
+      name: "{{ custID }}-controlplane"
       policies:
       - anti-affinity
     register: controlplaneGroup 
@@ -27,7 +27,7 @@
   - name: Create net2 worker server group
     openstack.cloud.server_group:
       state: present
-      name: worker-net2
+      name: "{{ custID }}-worker-net2"
       policies:
       - soft-anti-affinity
     register: workerNet2Group


### PR DESCRIPTION
- infraID isn't availiable yet and it's a rabbit-hole to reorder or add them to common.yaml, so just use custID
- Tested for deployment, and confirmed down playbook works.