### PR TITLE
Quick tweak... 

### DIFF
--- a/templates/install-config.j2
+++ b/templates/install-config.j2
@@ -31,6 +31,7 @@ networking:
 platform:
   openstack:
     apiVIP: {{ os_apiVIP }}
+    defaultMachinePlatform: {}
     cloud: openstack
     clusterOSImage: {{ rhcosImage }}
     externalDNS:


### PR DESCRIPTION
v4.9.0 installer pukes hard if defaultMachinePlatform isn't in install-config.yaml!

The parameter is "Optional" in 4.6-4.9 but if it is missing, the v4.9.0 installer does this:

```
$ openshift-install create manifests --dir=./
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x3188ca6]

goroutine 1 [running]:
github.com/openshift/installer/pkg/types/openstack/validation.validateDefaultMachinePool(0x0, 0xc000f5d080, 0x16, 0x0, 0x0)
        /go/src/github.com/openshift/installer/pkg/types/openstack/validation/machinepool.go:43 +0x26
github.com/openshift/installer/pkg/types/openstack/validation.ValidatePlatform(0xc0005a3400, 0xc000e17cb0, 0xc000f5d050, 0xc000760480, 0x0, 0x0, 0xc000f5d050)
        /go/src/github.com/openshift/installer/pkg/types/openstack/validation/platform.go:37 +0x2a5
github.com/openshift/installer/pkg/types/validation.validatePlatform.func7(0xc000f5d050, 0x10460ac0, 0x9, 0x0)
        /go/src/github.com/openshift/installer/pkg/types/validation/installconfig.go:465 +0x4a
github.com/openshift/installer/pkg/types/validation.validatePlatform.func1(0x10460ac0, 0x9, 0xd88fe20, 0xc0005a3400, 0xc0008e6c58)
        /go/src/github.com/openshift/installer/pkg/types/validation/installconfig.go:444 +0x29b
github.com/openshift/installer/pkg/types/validation.validatePlatform(0xc0007605f0, 0xc000f5d020, 0xc000e17cb0, 0xc000760480, 0x0, 0xc000f5d020, 0x8)
        /go/src/github.com/openshift/installer/pkg/types/validation/installconfig.go:464 +0x582
github.com/openshift/installer/pkg/types/validation.ValidateInstallConfig(0xc000760480, 0x0, 0xc0008e7088, 0x40e218)
        /go/src/github.com/openshift/installer/pkg/types/validation/installconfig.go:110 +0x5a5
github.com/openshift/installer/pkg/asset/installconfig.(*InstallConfig).finish(0xc000e78780, 0x104d03a5, 0x13, 0xf7e, 0x1018d6e0)
        /go/src/github.com/openshift/installer/pkg/asset/installconfig/installconfig.go:155 +0x99
github.com/openshift/installer/pkg/asset/installconfig.(*InstallConfig).Load(0xc000e78780, 0x11bf7260, 0xc00052b290, 0x11cfc758, 0xc000e78780, 0xc000e78780)
        /go/src/github.com/openshift/installer/pkg/asset/installconfig/installconfig.go:136 +0x1f3
github.com/openshift/installer/pkg/asset/store.(*storeImpl).load(0xc00052fdd0, 0x11c243a8, 0xc000e78330, 0xc00052c65c, 0x4, 0xc00052c65c, 0x4, 0x0)
        /go/src/github.com/openshift/installer/pkg/asset/store/store.go:264 +0x455
github.com/openshift/installer/pkg/asset/store.(*storeImpl).load(0xc00052fdd0, 0x11c24378, 0xc000524560, 0x10449fa0, 0x2, 0x10449fa0, 0x2, 0x0)
        /go/src/github.com/openshift/installer/pkg/asset/store/store.go:247 +0x2d7
github.com/openshift/installer/pkg/asset/store.(*storeImpl).load(0xc00052fdd0, 0x11c24648, 0x19c3ef60, 0x0, 0x0, 0x2, 0x2, 0x0)
        /go/src/github.com/openshift/installer/pkg/asset/store/store.go:247 +0x2d7
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc00052fdd0, 0x11c24648, 0x19c3ef60, 0x0, 0x0, 0x40b845, 0xebbb660)
        /go/src/github.com/openshift/installer/pkg/asset/store/store.go:201 +0xa45
github.com/openshift/installer/pkg/asset/store.(*storeImpl).Fetch(0xc00052fdd0, 0x11c24648, 0x19c3ef60, 0x19bea700, 0x4, 0x4, 0xed901e386, 0xef588d43d2f06cec)
        /go/src/github.com/openshift/installer/pkg/asset/store/store.go:77 +0x4b
main.runTargetCmd.func1(0x7fffd40f4d18, 0x2, 0xc000a0adf8, 0x0)
        /go/src/github.com/openshift/installer/cmd/openshift-install/create.go:238 +0x12d
main.runTargetCmd.func2(0x19bf90c0, 0xc00052b080, 0x0, 0x1)
        /go/src/github.com/openshift/installer/cmd/openshift-install/create.go:265 +0xb5
github.com/spf13/cobra.(*Command).execute(0x19bf90c0, 0xc00052b070, 0x1, 0x1, 0x19bf90c0, 0xc00052b070)
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc00028e840, 0xc0008e7de8, 0x1, 0x1)
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:895
main.installerMain()
        /go/src/github.com/openshift/installer/cmd/openshift-install/main.go:72 +0x2fe
main.main()
        /go/src/github.com/openshift/installer/cmd/openshift-install/main.go:50 +0x259

```