### PR TITLE
Add missing dependency of community.general.xml to pip-requirements file

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -6,3 +6,4 @@ python-octaviaclient>=2.4.0
 jmespath>=0.10.0
 openshift~=0.11.2
 PyYAML>=5.3.1
+lxml>=2.3.0


### PR DESCRIPTION
Listed as a requirement [here](https://docs.ansible.com/ansible/2.10/collections/community/general/xml_module.html#requirements) 