### PR TITLE
Hotfix for 4.10 machinesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ watch -n5 oc get nodes
 ansible-playbook -i ./inventory.yaml ./down-compute-nodes.yaml
 ansible-playbook -i ./inventory.yaml ./down-control-plane.yaml
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-bootstrap.yaml
-ansible-playbook -i ./inventory.yaml ./down-bastion.yaml
 ansible-playbook -i ./inventory.yaml ./down-loadbalancers.yaml
 # The down-network playbook needs to be run twice due to ha_router port removal occasionally failing for net2/eg deployments
 ansible-playbook -e @vars.yml -i ./inventory.yaml ./down-network.yaml

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ pip install -r pip-requirements.txt
 oc delete project ukc-ingress 
 oc delete MachineSets --all -n openshift-machine-api
 oc scale IngressControllers --all --replicas=0 -n openshift-ingress-operator
-oc delete pdb prometheus-adapter thanos-querier-pdb -n openshift-monitoring
+oc delete pdb prometheus-adapter thanos-querier-pdb alertmanager-main prometheus-k8s -n openshift-monitoring
+oc delete pdb prometheus-user-workload thanos-ruler-user-workload -n openshift-user-workload-monitoring
 # Wait for workers/infra/net2 to vanish - last worker takes ages...
 watch -n5 oc get nodes
 

--- a/manifests.yaml
+++ b/manifests.yaml
@@ -110,6 +110,12 @@
       insertafter: '^\s{10}image.*$'
       line: '          serverGroupID: {{ workerDefault.id }}'
 
+  - name: Remove ServerGroupName in worker server groups
+    lineinfile:
+      path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml
+      state: absent
+      regexp: 'serverGroupName'    
+
   - name: Add label for default node selector
     replace:
       path: openshift/99_openshift-cluster-api_worker-machineset-0.yaml

--- a/net2-manifests.yaml
+++ b/net2-manifests.yaml
@@ -11,6 +11,12 @@
       insertafter: '^\s{10}image.*$'
       line: '          serverGroupID: {{ workerNet2Group.id }}'
 
+  - name: Remove ServerGroupName in worker server groups
+    lineinfile:
+      path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml
+      state: absent
+      regexp: 'serverGroupName'      
+
   - name: Add label for net2 node selector
     replace:
       path: openshift/99_openshift-cluster-api_net2_worker-machineset-0.yaml


### PR DESCRIPTION
- Add task to remove the serverGroupName machineset param added by 4.10 installer - it conflicts with the serverGroupID added by our automation (should have no effect on 4.9 etc) 
- Slight updates to README.md guide to the "down procedure"