### PR TITLE
Uplift openshift python module

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,6 +3,6 @@ openstacksdk>=0.59.0
 python-openstackclient>=5.6.0
 python-octaviaclient>=2.4.0
 jmespath>=0.10.0
-openshift~=0.11.2
+openshift~=0.13.1
 PyYAML>=5.3.1
 lxml>=2.3.0


### PR DESCRIPTION
Doing this should make the ansible openshift and kubernetes modules work again.